### PR TITLE
Solve a sharing violation on windows

### DIFF
--- a/generator/vulkan/build-integration.zig
+++ b/generator/vulkan/build-integration.zig
@@ -53,6 +53,7 @@ pub const GenerateStep = struct {
         const dir = path.dirname(self.full_out_path).?;
         try cwd.makePath(dir);
         const output_file = cwd.createFile(self.full_out_path, .{}) catch unreachable;
+        defer output_file.close();
         _ = try std.zig.render(self.builder.allocator, output_file.outStream(), tree);
     }
 };


### PR DESCRIPTION
On windows because we fail to close the output_file, when the compiler 
goes to open it when reading the file during compiling the actual app it
encounters a sharing violation. This change closes the file, fixing that issue