### PR TITLE
Removed special case for member pNext.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Vulkan binding generator for Zig.
 
 vulkan-zig attempts to provide a better experience to programming Vulkan applications in Zig, by providing features such as integration of vulkan errors with Zig's error system, function pointer loading, renaming fields to standard Zig style, better bitfield handling, turning out parameters into return values and more.
 
-vulkan-zig is automatically tested against the latest vk.xml and zig, and supports vk.xml from version 1.x.141.
+vulkan-zig is automatically tested against the latest vk.xml and zig, and supports vk.xml from version 1.x.163.
 
 ## Features
 ### CLI-interface

--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -190,11 +190,6 @@ fn parseContainer(allocator: *Allocator, ty: *xml.Element, is_union: bool) !regi
     for (members) |*member| {
         const member_elem = it.next().?;
         try parsePointerMeta(.{.container = members}, &member.field_type, member_elem);
-
-        // pNext isn't properly marked as optional, so just manually override it,
-        if (mem.eql(u8, member.name, "pNext")) {
-            member.field_type.pointer.is_optional = true;
-        }
     }
 
     return registry.Declaration {


### PR DESCRIPTION
Before discovering this repository i was working on my own vulkan bindings generator and also noticed that pNext was not marked as optional. I got a pull request through in the Vulkan-Docs repo so now it's correctly marked as optional. 

This PR depends on #4 for the triangle example to work.