### PR TITLE
add native support for Zigmod package manager

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -1,0 +1,6 @@
+id: uxw7q1ovyv4z3t7fi28agxovmhbrobglw7mwtl5p3pnsc1gu
+name: vulkan-zig
+main: generator/index.zig
+license: MIT
+description: Vulkan binding generator for Zig
+dependencies:


### PR DESCRIPTION
Note: requires <https://github.com/nektro/zigmod/releases/tag/v48> or later.

With this change, users can incorporate into their `build.zig` via the following:

```zig
const deps = @import("./deps.zig");
const vkgen = deps.imports.vulkan_zig;

// ... using `vkgen` as normal
```