### PR TITLE
Implements default for feature structs

### DIFF
--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -205,6 +205,18 @@ fn parseContainer(allocator: *Allocator, ty: *xml.Element, is_union: bool) !regi
 
     members = allocator.shrink(members, i);
 
+    var maybe_extends: ?[][]const u8 = null;
+    if (ty.getAttribute("structextends")) |extends| {
+        const n_structs = std.mem.count(u8, extends, ",") + 1;
+        maybe_extends = try allocator.alloc([]const u8, n_structs);
+        var struct_extends = std.mem.split(extends, ",");
+        var j: usize = 0;
+        while (struct_extends.next()) |struct_extend| {
+            maybe_extends.?[j] = struct_extend;
+            j += 1;
+        }
+    }
+
     it = ty.findChildrenByTag("member");
     for (members) |*member| {
         const member_elem = it.next().?;
@@ -218,6 +230,7 @@ fn parseContainer(allocator: *Allocator, ty: *xml.Element, is_union: bool) !regi
                 .stype = maybe_stype,
                 .fields = members,
                 .is_union = is_union,
+                .extends = maybe_extends,
             },
         },
     };

--- a/generator/vulkan/registry.zig
+++ b/generator/vulkan/registry.zig
@@ -65,6 +65,7 @@ pub const Container = struct {
     };
 
     stype: ?[]const u8,
+    extends: ?[]const []const u8,
     fields: []Field,
     is_union: bool,
 };

--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -728,7 +728,18 @@ fn Renderer(comptime WriterType: type) type {
 
                 try self.writer.writeAll(" = .");
                 try self.writeIdentifierWithCase(.snake, stype["VK_STRUCTURE_TYPE_".len..]);
+            } else if (field.field_type == .name and !container.is_union and mem.eql(u8, "VkBool32", field.field_type.name) and isFeatureStruct(container.extends)) {
+                try self.writer.writeAll(" = FALSE");
             }
+        }
+
+        fn isFeatureStruct(maybe_extends: ?[]const []const u8) bool {
+            if (maybe_extends) |extends| {
+                return for (extends) |extend| {
+                    if (mem.eql(u8, extend, "VkDeviceCreateInfo")) break true;
+                } else false;
+            }
+            return false;
         }
 
         fn renderEnumFieldName(self: *Self, name: []const u8, field_name: []const u8) !void {


### PR DESCRIPTION
In Zig, unlike C, you have to initialize everything explicitly. 

This is generally good, but sometimes in Vulkan you are expected to make use of the C/C++ ability to zero-initialize unmentioned fields, particularly in feature structs.

For example, currently you have to do this if you're using `vulkan-zig`:
```zig
const device_features = vk.PhysicalDeviceVulkan12Features {
    .buffer_device_address = vk.TRUE,
    .sampler_mirror_clamp_to_edge = vk.FALSE,
    .draw_indirect_count = vk.FALSE,
    .storage_buffer_8_bit_access = vk.FALSE,
    .uniform_and_storage_buffer_8_bit_access = vk.FALSE,
    .storage_push_constant_8 = vk.FALSE,
    .shader_buffer_int_64_atomics = vk.FALSE,
    .shader_shared_int_64_atomics = vk.FALSE,
    .shader_float_16 = vk.FALSE,
    .shader_int_8 = vk.FALSE,
    .descriptor_indexing = vk.FALSE,
    .shader_input_attachment_array_dynamic_indexing = vk.FALSE,
    .shader_uniform_texel_buffer_array_dynamic_indexing = vk.FALSE,
    .shader_storage_texel_buffer_array_dynamic_indexing = vk.FALSE,
    .shader_uniform_buffer_array_non_uniform_indexing = vk.FALSE,
    .shader_sampled_image_array_non_uniform_indexing = vk.FALSE,
    .shader_storage_buffer_array_non_uniform_indexing = vk.FALSE,
    .shader_storage_image_array_non_uniform_indexing = vk.FALSE,
    .shader_input_attachment_array_non_uniform_indexing = vk.FALSE,
    .shader_uniform_texel_buffer_array_non_uniform_indexing = vk.FALSE,
    .shader_storage_texel_buffer_array_non_uniform_indexing = vk.FALSE,
    .descriptor_binding_uniform_buffer_update_after_bind = vk.FALSE,
    .descriptor_binding_sampled_image_update_after_bind = vk.FALSE,
    .descriptor_binding_storage_image_update_after_bind = vk.FALSE,
    .descriptor_binding_storage_buffer_update_after_bind = vk.FALSE,
    .descriptor_binding_uniform_texel_buffer_update_after_bind = vk.FALSE, 
    .descriptor_binding_storage_texel_buffer_update_after_bind = vk.FALSE,
    .descriptor_binding_update_unused_while_pending = vk.FALSE,
    .descriptor_binding_partially_bound = vk.FALSE,
    .descriptor_binding_variable_descriptor_count = vk.FALSE,
    .runtime_descriptor_array = vk.FALSE,
    .sampler_filter_minmax = vk.FALSE,
    .scalar_block_layout = vk.FALSE,
    .imageless_framebuffer = vk.FALSE,
    .uniform_buffer_standard_layout = vk.FALSE,
    .shader_subgroup_extended_types = vk.FALSE,
    .separate_depth_stencil_layouts = vk.FALSE,
    .host_query_reset = vk.FALSE,
    .timeline_semaphore = vk.FALSE,
    .buffer_device_address_capture_replay = vk.FALSE,
    .buffer_device_address_multi_device = vk.FALSE,
    .vulkan_memory_model = vk.FALSE,
    .vulkan_memory_model_device_scope = vk.FALSE,
    .vulkan_memory_model_availability_visibility_chains = vk.FALSE,
    .shader_output_viewport_index = vk.FALSE,
    .shader_output_layer = vk.FALSE,
    .subgroup_broadcast_dynamic_id = vk.FALSE,
};
```
when in C you'd just do this:
```c
PhysicalDeviceVulkan12Features device_features = {
     .BufferDeviceAddress = VK_TRUE,
};
```
This PR attempts to remedy that a bit - if a struct is heuristically detected as a feature struct, it sets the `VkBool32` values to the default of `VK_FALSE`.

Now you can do this:
```zig
const device_features = vk.PhysicalDeviceVulkan12Features {
    .buffer_device_address = vk.TRUE,
};
```