### PR TITLE
examples: do not call glfwSwapBuffers

### DIFF
--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -150,7 +150,6 @@ pub fn main() !void {
             );
         }
 
-        c.glfwSwapBuffers(window);
         c.glfwPollEvents();
     }
 


### PR DESCRIPTION
I am porting this example to [mach-glfw](github.com/hexops/mach-glfw), and noticed that no GLFW error handling callback is registered because in my port there are a lot of GLFW errors :)

`glfwSwapBuffers` here is emitting `GLFW_NO_WINDOW_CONTEXT` errors constantly, because calling it without a valid OpenGL context is illegal. It's not needed for Vulkan.