### PR TITLE
improve glslc invocation compatability with macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ pub fn build(b: *Builder) void {
 
     const shader_comp = vkgen.ShaderCompileStep.init(
         builder,
-        &[_][]const u8{"glslc", "--target-env=vulkan1.2"}, // Path to glslc and additional parameters
+        &[_][]const u8{"glslc", "--target-env", "vulkan1.2"}, // Path to glslc and additional parameters
     );
     exe.step.dependOn(&shader_comp.step);
     const spv_path = shader_comp.addShader("path/to/shader.frag");

--- a/build.zig
+++ b/build.zig
@@ -21,7 +21,7 @@ pub const ResourceGenStep = struct {
 
         self.* = .{
             .step = Step.init(.custom, "resources", builder.allocator, make),
-            .shader_step = vkgen.ShaderCompileStep.init(builder, &[_][]const u8{ "glslc", "--target-env=vulkan1.2" }),
+            .shader_step = vkgen.ShaderCompileStep.init(builder, &[_][]const u8{ "glslc", "--target-env", "vulkan1.2" }),
             .builder = builder,
             .package = .{
                 .name = "resources",


### PR DESCRIPTION
It's annoying to install `glslc` on macOS, but what is available is `glslangValidator`
which similarly can be invoked to compile GLSL shaders -> SPIR-V. It's nice to use
this because Homebrew has it:

```
brew install glslang
sudo ln -s $(which glslangValidator) /usr/local/bin/glslc
```

However, `glslc --target-env=vulkan1.2` is not supported with an `=` between the flag
and value. `glslc --target-env vulkan1.2` works, though, so I am proposing this minor
change.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>