### PR TITLE
Replace `anytype` with explicit `[]const {s}Command`

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -5,11 +5,11 @@ const Allocator = std.mem.Allocator;
 
 const required_device_extensions = [_][]const u8{vk.extension_info.khr_swapchain.name};
 
-const BaseDispatch = vk.BaseWrapper(.{
+const BaseDispatch = vk.BaseWrapper(&.{
     .createInstance,
 });
 
-const InstanceDispatch = vk.InstanceWrapper(.{
+const InstanceDispatch = vk.InstanceWrapper(&.{
     .destroyInstance,
     .createDevice,
     .destroySurfaceKHR,
@@ -25,7 +25,7 @@ const InstanceDispatch = vk.InstanceWrapper(.{
     .getDeviceProcAddr,
 });
 
-const DeviceDispatch = vk.DeviceWrapper(.{
+const DeviceDispatch = vk.DeviceWrapper(&.{
     .destroyDevice,
     .getDeviceQueue,
     .createSemaphore,

--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -1015,10 +1015,9 @@ fn Renderer(comptime WriterType: type) type {
             };
 
             try self.writer.print(
-                \\pub fn {s}Wrapper(comptime cmds: anytype) type {{
-                \\    const cmd_array: [cmds.len]{s}Command = cmds;
+                \\pub fn {s}Wrapper(comptime cmds: []const {s}Command) type {{
                 \\    comptime var fields: [cmds.len]std.builtin.TypeInfo.StructField = undefined;
-                \\    inline for (cmd_array) |cmd, i| {{
+                \\    inline for (cmds) |cmd, i| {{
                 \\        const PfnType = cmd.PfnType();
                 \\        fields[i] = .{{
                 \\            .name = cmd.symbol(),


### PR DESCRIPTION
Pros:
 * Slightly better error message when passing in a non-existent enum value (points at caller's argument instead of the point in the function where the enum literal fails to coerce).
 * Clearer function signature.
 * Removes the possibility of, eg. `BaseWrapper([_]BaseCommand{ .createInstance })` not being equal to `BaseWrapper(.{ .createInstance })`, thanks to coercion happening at the callsite, and erego evading possible code bloat in niche circumstances.

Cons:
 * Breaking, since `.{ ... }` doesn't coerce to being a slice; though, this would be a quick fix, by just prefixing it with '&', a la `&.{ ... }`.
* (Am I missing anything?)

Context:
I was trying to make some functions generic over possible `InstanceWrapper` productions, and ran into an issue where, in a type-checking function `isInstanceWrapper(comptime T: type)` returned false for `InstanceWrapper(.{ ... })` but true for `InstanceWrapper([_]InstanceCommand{ ... })`. With this change, that would be solved for. But if this isn't accepted, I can always find a different way around. 