### PR TITLE
use Allocator.dupe instead of std.mem.dupe

### DIFF
--- a/generator/xml.zig
+++ b/generator/xml.zig
@@ -422,7 +422,7 @@ fn tryParseAttr(ctx: *ParseContext, alloc: *Allocator) !?*Attribute {
     const value = try parseAttrValue(ctx, alloc);
 
     const attr = try alloc.create(Attribute);
-    attr.name = try mem.dupe(alloc, u8, name);
+    attr.name = try alloc.dupe(u8, name);
     attr.value = value;
     return attr;
 }
@@ -436,7 +436,7 @@ fn tryParseElement(ctx: *ParseContext, alloc: *Allocator) !?*Element {
     };
 
     const element = try alloc.create(Element);
-    element.* = Element.init(try std.mem.dupe(alloc, u8, tag), alloc);
+    element.* = Element.init(try alloc.dupe(u8, tag), alloc);
 
     while (ctx.eatWs()) {
         const attr = (try tryParseAttr(ctx, alloc)) orelse break;
@@ -601,7 +601,7 @@ fn tryParseComment(ctx: *ParseContext, alloc: *Allocator) !?[]const u8 {
     }
 
     const end = ctx.offset - "-->".len;
-    return try mem.dupe(alloc, u8, ctx.source[begin..end]);
+    return try alloc.dupe(u8, ctx.source[begin..end]);
 }
 
 fn unescapeEntity(text: []const u8) !u8 {


### PR DESCRIPTION
`std.mem.dupe` was recently hard deprecated:
```zig
ziglang/zig/build/lib/zig/std/mem.zig:908:18: error: deprecated; use `Allocator.dupe`
pub const dupe = @compileError("deprecated; use `Allocator.dupe`");
                 ^
./generator/xml.zig:604:19: note: referenced here
    return try mem.dupe(alloc, u8, ctx.source[begin..end]);
                  ^
./generator/xml.zig:590:12: note: referenced here
    while (try tryParseComment(ctx, alloc)) |_| {
           ^
./generator/xml.zig:331:5: note: referenced here
    try trySkipComments(ctx, &doc.arena.allocator);
    ^
./generator/xml.zig:319:12: note: referenced here
    return try parseDocument(&ctx, backing_allocator);
           ^
./generator/vulkan/generator.zig:178:18: note: referenced here
    const spec = try xml.parse(allocator, spec_xml);
                 ^
./generator/vulkan/build_integration.zig:78:9: note: referenced here
        try generate(self.builder.allocator, spec, out_buffer.writer());
        ^
```

thanks for all the work on the bindings btw (: