### PR TITLE
Fix order of handling of optional error union type in generator

### DIFF
--- a/generator/main.zig
+++ b/generator/main.zig
@@ -11,14 +11,12 @@ pub fn main() !void {
     const allocator = arena.allocator();
 
     var args = std.process.args();
-    const prog_name = try args.next(allocator) orelse return error.ExecutableNameMissing;
+    const prog_name = (try args.next(allocator)) orelse return error.ExecutableNameMissing;
 
     var maybe_xml_path: ?[]const u8 = null;
     var maybe_out_path: ?[]const u8 = null;
 
-    while (args.next(allocator)) |err_or_arg| {
-        const arg = try err_or_arg;
-
+    while (try args.next(allocator)) |arg| {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             @setEvalBranchQuota(2000);
             try stderr.writer().print(


### PR DESCRIPTION
The generator no longer compiles because of changes to the return type of ArgIterator.next(). ArgIterator.next() returns an optional error union type, the potential error has to be handled before the optional can be unwrapped.