### PR TITLE
Copy array of strings instead of assuming lifetime

### DIFF
--- a/generator/build_integration.zig
+++ b/generator/build_integration.zig
@@ -32,7 +32,7 @@ pub const ShaderCompileStep = struct {
         self.* = .{
             .step = Step.init(.custom, "shader-compile", builder.allocator, make),
             .builder = builder,
-            .glslc_cmd = glslc_cmd,
+            .glslc_cmd = builder.dupeStrings(glslc_cmd),
             .shaders = std.ArrayList(Shader).init(builder.allocator),
         };
         return self;


### PR DESCRIPTION
Current setup works fine if passed static memory like '&.{ "glslc" }', but produces errors of various types (segmentation faults, access denied, file doesn't exist, etc) if passed a runtime-known slice, such as a slice containing the result of a call to `Builder.pathJoin`, a la `const glslc_cmd = b.pathJoin(&.{ b.env_map.get("VULKAN_SDK").?, "bin", "glslc" })`, which could then be naively passed as `&.{ glslc_cmd }`. This change prevents issues with temporary runtime argument values.