### PR TITLE
update to latest zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub const ResourceGenStep = struct {
             .builder = builder,
             .package = .{
                 .name = "resources",
-                .path = .{ .generated = &self.output_file },
+                .source = .{ .generated = &self.output_file },
                 .dependencies = null,
             },
             .output_file = .{

--- a/generator/vulkan/build_integration.zig
+++ b/generator/vulkan/build_integration.zig
@@ -40,7 +40,7 @@ pub const GenerateStep = struct {
             .spec_path = spec_path,
             .package = .{
                 .name = "vulkan",
-                .path = .{ .generated = &self.output_file },
+                .source = .{ .generated = &self.output_file },
                 .dependencies = null,
             },
             .output_file = .{


### PR DESCRIPTION
``Pkg.path`` was renamed to ``Pkg.source`` in commit https://github.com/ziglang/zig/commit/4e918873e7667e8d74b009cb34cbdd4df3305462