### PR TITLE
Add support for multiple entrypoints, specifying stage, and a custom output file for shader compilation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -56,7 +56,7 @@ pub const ResourceGenStep = struct {
     }
 
     pub fn addShader(self: *ResourceGenStep, name: []const u8, source: []const u8) void {
-        const shader_out_path = self.shader_step.add(source);
+        const shader_out_path = self.shader_step.add(source, .{});
         var writer = self.resources.writer();
 
         writer.print("pub const {s} = @embedFile(\"", .{name}) catch unreachable;

--- a/generator/build_integration.zig
+++ b/generator/build_integration.zig
@@ -3,10 +3,27 @@ const path = std.fs.path;
 const Builder = std.build.Builder;
 const Step = std.build.Step;
 
+/// Stage the shader should be built for. This is passed to the -fshader-stage
+/// argument when invoking glslc.
+pub const ShaderStage = enum {
+    vertex,
+    fragment,
+    tesscontrol,
+    tesseval,
+    geometry,
+    compute,
+};
+
 /// Utility functionality to help with compiling shaders from build.zig.
 /// Invokes glslc (or another shader compiler passed to `init`) for each shader
 /// added via `addShader`.
 pub const ShaderCompileStep = struct {
+    const AddFileParams = struct {
+        entry_point: ?[]const u8 = null,
+        stage: ?ShaderStage = null,
+        output_filename: ?[]const u8 = null,
+    };
+
     /// Structure representing a shader to be compiled.
     const Shader = struct {
         /// The path to the shader, relative to the current build root.
@@ -14,6 +31,13 @@ pub const ShaderCompileStep = struct {
 
         /// The full output path where the compiled shader binary is placed.
         full_out_path: []const u8,
+
+        /// The entry point to use when compiling the shader.
+        entry_point: ?[]const u8,
+
+        /// The stage to use when building. If not null, this is passed to
+        /// the -fshader-stage argument.
+        stage: ?ShaderStage,
     };
 
     step: Step,
@@ -45,16 +69,15 @@ pub const ShaderCompileStep = struct {
     /// Add a shader to be compiled. `src` is shader source path, relative to the project root.
     /// Returns the full path where the compiled binary will be stored upon successful compilation.
     /// This path can then be used to include the binary into an executable, for example by passing it
-    /// to @embedFile via an additional generated file.
-    pub fn add(self: *ShaderCompileStep, src: []const u8) []const u8 {
-        const output_filename = std.fmt.allocPrint(self.builder.allocator, "{s}.spv", .{ src }) catch unreachable;
+    /// to @embedFile via an additional generated file. `entry_point` is the entry point to pass to the compiler.
+    /// `stage` is an optional shader stage to pass to the compiler with the flag `-fshader-stage` when building the shader.
+    pub fn add(self: *ShaderCompileStep, src: []const u8, params: AddFileParams) []const u8 {
         const full_out_path = path.join(self.builder.allocator, &[_][]const u8{
             self.builder.build_root,
             self.builder.cache_root,
-            self.output_dir,
-            output_filename,
+            if (params.output_filename) |out| out else std.fmt.allocPrint(self.builder.allocator, "{s}.spv", .{src}) catch unreachable,
         }) catch unreachable;
-        self.shaders.append(.{ .source_path = src, .full_out_path = full_out_path }) catch unreachable;
+        self.shaders.append(.{ .source_path = src, .full_out_path = full_out_path, .entry_point = params.entry_point, .stage = params.stage }) catch unreachable;
         return full_out_path;
     }
 
@@ -63,18 +86,30 @@ pub const ShaderCompileStep = struct {
         const self = @fieldParentPtr(ShaderCompileStep, "step", step);
         const cwd = std.fs.cwd();
 
-        const cmd = try self.builder.allocator.alloc([]const u8, self.glslc_cmd.len + 3);
+        const cmd = try self.builder.allocator.alloc([]const u8, self.glslc_cmd.len + 5);
         for (self.glslc_cmd) |part, i| {
             cmd[i] = part;
         }
-        cmd[cmd.len - 2] = "-o";
 
         for (self.shaders.items) |shader| {
+            var argc: usize = cmd.len - 2;
+
+            if (shader.entry_point) |entry_point| {
+                cmd[argc - 3] = try std.fmt.allocPrint(self.builder.allocator, "-fentry-point={s}", .{entry_point});
+                argc += 1;
+            }
+
+            if (shader.stage) |stage| {
+                cmd[argc - 3] = try std.fmt.allocPrint(self.builder.allocator, "-fshader-stage={s}", .{@tagName(stage)});
+                argc += 1;
+            }
+
             const dir = path.dirname(shader.full_out_path).?;
             try cwd.makePath(dir);
-            cmd[cmd.len - 3] = shader.source_path;
-            cmd[cmd.len - 1] = shader.full_out_path;
-            try self.builder.spawnChild(cmd);
+            cmd[argc - 3] = shader.source_path;
+            cmd[argc - 2] = "-o";
+            cmd[argc - 1] = shader.full_out_path;
+            try self.builder.spawnChild(cmd[0..argc]);
         }
     }
 };

--- a/generator/index.zig
+++ b/generator/index.zig
@@ -1,5 +1,6 @@
 pub const generateVk = @import("vulkan/generator.zig").generate;
 pub const VkGenerateStep = @import("vulkan/build_integration.zig").GenerateStep;
+pub const ShaderStage = @import("build_integration.zig").ShaderStage;
 pub const ShaderCompileStep = @import("build_integration.zig").ShaderCompileStep;
 
 test "main" {


### PR DESCRIPTION
Hello! I have added some functionality to support multiple entrypoints, as I have some HLSL shaders that have two entrypoints I'd like to use without changing. I've tried to make the interface change relatively small, but it does change it in that calls to `add` need to pass an empty param object.

An alternative which would avoid the interface change would be to add a second function `addWithOptions` or something like that. Please LMK if you prefer that.