### PR TITLE
Fix field_type -> field, introduce addShaderBase64

### DIFF
--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -1130,7 +1130,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\                    const PfnType = {0s}CommandFlags.CmdType(field_tag);
                 \\                    fields[i] = .{{
                 \\                        .name = {0s}CommandFlags.cmdName(field_tag),
-                \\                        .field_type = PfnType,
+                \\                        .type = PfnType,
                 \\                        .default_value = null,
                 \\                        .is_comptime = false,
                 \\                        .alignment = @alignOf(PfnType),
@@ -1185,7 +1185,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\    inline for (std.meta.fields(Dispatch)) |field| {{
                 \\        const name = @ptrCast([*:0]const u8, field.name ++ "\x00");
                 \\        const cmd_ptr = loader({[first_arg]s}, name) orelse return error.CommandLoadFailure;
-                \\        @field(self.dispatch, field.name) = @ptrCast(field.field_type, cmd_ptr);
+                \\        @field(self.dispatch, field.name) = @ptrCast(field.type, cmd_ptr);
                 \\    }}
                 \\    return self;
                 \\}}
@@ -1194,7 +1194,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\    inline for (std.meta.fields(Dispatch)) |field| {{
                 \\        const name = @ptrCast([*:0]const u8, field.name ++ "\x00");
                 \\        const cmd_ptr = loader({[first_arg]s}, name) orelse undefined;
-                \\        @field(self.dispatch, field.name) = @ptrCast(field.field_type, cmd_ptr);
+                \\        @field(self.dispatch, field.name) = @ptrCast(field.type, cmd_ptr);
                 \\    }}
                 \\    return self;
                 \\}}


### PR DESCRIPTION
field_type rename according to https://github.com/ziglang/zig/commit/aac2d6b56f32134ea32fb3d984e3fcdfddd8aaf6

addShaderBase64 allows for the inclusion of spv binaries without using @embedFile, since @embedFile has certain restrictions on file locations.