### PR TITLE
More defaults for struct fields

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -109,10 +109,7 @@ pub const GraphicsContext = struct {
         };
 
         self.instance = try self.vkb.createInstance(&.{
-            .flags = .{},
             .p_application_info = &app_info,
-            .enabled_layer_count = 0,
-            .pp_enabled_layer_names = undefined,
             .enabled_extension_count = glfw_exts_count,
             .pp_enabled_extension_names = @ptrCast([*]const [*:0]const u8, glfw_exts),
         }, null);
@@ -192,13 +189,11 @@ fn initializeCandidate(vki: InstanceDispatch, candidate: DeviceCandidate) !vk.De
     const priority = [_]f32{1};
     const qci = [_]vk.DeviceQueueCreateInfo{
         .{
-            .flags = .{},
             .queue_family_index = candidate.queues.graphics_family,
             .queue_count = 1,
             .p_queue_priorities = &priority,
         },
         .{
-            .flags = .{},
             .queue_family_index = candidate.queues.present_family,
             .queue_count = 1,
             .p_queue_priorities = &priority,
@@ -211,14 +206,10 @@ fn initializeCandidate(vki: InstanceDispatch, candidate: DeviceCandidate) !vk.De
         2;
 
     return try vki.createDevice(candidate.pdev, &.{
-        .flags = .{},
         .queue_create_info_count = queue_count,
         .p_queue_create_infos = &qci,
-        .enabled_layer_count = 0,
-        .pp_enabled_layer_names = undefined,
         .enabled_extension_count = required_device_extensions.len,
         .pp_enabled_extension_names = @ptrCast([*]const [*:0]const u8, &required_device_extensions),
-        .p_enabled_features = null,
     }, null);
 }
 

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -47,7 +47,6 @@ pub const Swapchain = struct {
             .exclusive;
 
         const handle = try gc.vkd.createSwapchainKHR(gc.dev, &.{
-            .flags = .{},
             .surface = gc.surface,
             .min_image_count = image_count,
             .image_format = surface_format.format,
@@ -77,7 +76,7 @@ pub const Swapchain = struct {
             allocator.free(swap_images);
         }
 
-        var next_image_acquired = try gc.vkd.createSemaphore(gc.dev, &.{ .flags = .{} }, null);
+        var next_image_acquired = try gc.vkd.createSemaphore(gc.dev, &.{}, null);
         errdefer gc.vkd.destroySemaphore(gc.dev, next_image_acquired, null);
 
         const result = try gc.vkd.acquireNextImageKHR(gc.dev, handle, std.math.maxInt(u64), next_image_acquired, .null_handle);
@@ -172,7 +171,6 @@ pub const Swapchain = struct {
             .swapchain_count = 1,
             .p_swapchains = @ptrCast([*]const vk.SwapchainKHR, &self.handle),
             .p_image_indices = @ptrCast([*]const u32, &self.image_index),
-            .p_results = null,
         });
 
         // Step 4: Acquire next frame
@@ -204,7 +202,6 @@ const SwapImage = struct {
 
     fn init(gc: *const GraphicsContext, image: vk.Image, format: vk.Format) !SwapImage {
         const view = try gc.vkd.createImageView(gc.dev, &.{
-            .flags = .{},
             .image = image,
             .view_type = .@"2d",
             .format = format,
@@ -219,10 +216,10 @@ const SwapImage = struct {
         }, null);
         errdefer gc.vkd.destroyImageView(gc.dev, view, null);
 
-        const image_acquired = try gc.vkd.createSemaphore(gc.dev, &.{ .flags = .{} }, null);
+        const image_acquired = try gc.vkd.createSemaphore(gc.dev, &.{}, null);
         errdefer gc.vkd.destroySemaphore(gc.dev, image_acquired, null);
 
-        const render_finished = try gc.vkd.createSemaphore(gc.dev, &.{ .flags = .{} }, null);
+        const render_finished = try gc.vkd.createSemaphore(gc.dev, &.{}, null);
         errdefer gc.vkd.destroySemaphore(gc.dev, render_finished, null);
 
         const frame_fence = try gc.vkd.createFence(gc.dev, &.{ .flags = .{ .signaled_bit = true } }, null);

--- a/generator/vulkan/c_parse.zig
+++ b/generator/vulkan/c_parse.zig
@@ -263,6 +263,7 @@ pub fn parseMember(allocator: Allocator, xctok: *XmlCTokenizer, ptrs_optional: b
         .field_type = decl.decl_type,
         .bits = null,
         .is_buffer_len = false,
+        .is_optional = false,
     };
 
     if (try xctok.peek()) |tok| {

--- a/generator/vulkan/registry.zig
+++ b/generator/vulkan/registry.zig
@@ -61,6 +61,7 @@ pub const Container = struct {
         field_type: TypeInfo,
         bits: ?usize,
         is_buffer_len: bool,
+        is_optional: bool,
     };
 
     stype: ?[]const u8,


### PR DESCRIPTION
Given that using just the C Vulkan headers in C one can default-initialize a lot of Vulkan struct fields via struct initializers, it makes sense to follow that behavior in Zig as well.