### PR TITLE
Fixed code to conform to new multi-for syntax

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -147,7 +147,7 @@ pub const GraphicsContext = struct {
     }
 
     pub fn findMemoryTypeIndex(self: GraphicsContext, memory_type_bits: u32, flags: vk.MemoryPropertyFlags) !u32 {
-        for (self.mem_props.memory_types[0..self.mem_props.memory_type_count]) |mem_type, i| {
+        for (self.mem_props.memory_types[0..self.mem_props.memory_type_count], 0..) |mem_type, i| {
             if (memory_type_bits & (@as(u32, 1) << @truncate(u5, i)) != 0 and mem_type.property_flags.contains(flags)) {
                 return @truncate(u32, i);
             }
@@ -285,7 +285,7 @@ fn allocateQueues(vki: InstanceDispatch, pdev: vk.PhysicalDevice, allocator: All
     var graphics_family: ?u32 = null;
     var present_family: ?u32 = null;
 
-    for (families) |properties, i| {
+    for (families, 0..) |properties, i| {
         const family = @intCast(u32, i);
 
         if (graphics_family == null and properties.queue_flags.graphics_bit) {

--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -177,7 +177,7 @@ fn uploadVertices(gc: *const GraphicsContext, pool: vk.CommandPool, buffer: vk.B
         defer gc.vkd.unmapMemory(gc.dev, staging_memory);
 
         const gpu_vertices = @ptrCast([*]Vertex, @alignCast(@alignOf(Vertex), data));
-        for (vertices) |vertex, i| {
+        for (vertices, 0..) |vertex, i| {
             gpu_vertices[i] = vertex;
         }
     }
@@ -254,7 +254,7 @@ fn createCommandBuffers(
         .extent = extent,
     };
 
-    for (cmdbufs) |cmdbuf, i| {
+    for (cmdbufs, framebuffers) |cmdbuf, framebuffer| {
         try gc.vkd.beginCommandBuffer(cmdbuf, &.{});
 
         gc.vkd.cmdSetViewport(cmdbuf, 0, 1, @ptrCast([*]const vk.Viewport, &viewport));
@@ -268,7 +268,7 @@ fn createCommandBuffers(
 
         gc.vkd.cmdBeginRenderPass(cmdbuf, &.{
             .render_pass = render_pass,
-            .framebuffer = framebuffers[i],
+            .framebuffer = framebuffer,
             .render_area = render_area,
             .clear_value_count = 1,
             .p_clear_values = @ptrCast([*]const vk.ClearValue, &clear),

--- a/generator/vulkan/c_parse.zig
+++ b/generator/vulkan/c_parse.zig
@@ -549,7 +549,7 @@ pub fn parseVersion(xctok: *XmlCTokenizer) ![4][]const u8 {
 
     _ = try xctok.expect(.lparen);
     var version: [4][]const u8 = undefined;
-    for (version) |*part, i| {
+    for (&version, 0..) |*part, i| {
         if (i != 0) {
             _ = try xctok.expect(.comma);
         }

--- a/generator/vulkan/generator.zig
+++ b/generator/vulkan/generator.zig
@@ -103,7 +103,7 @@ pub const Generator = struct {
         const result = try parseXml(allocator, spec);
 
         const tags = try allocator.alloc([]const u8, result.registry.tags.len);
-        for (tags) |*tag, i| tag.* = result.registry.tags[i].name;
+        for (tags, result.registry.tags) |*tag, registry_tag| tag.* = registry_tag.name;
 
         return Generator{
             .arena = result.arena,

--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -115,8 +115,8 @@ fn eqlIgnoreCase(lhs: []const u8, rhs: []const u8) bool {
         return false;
     }
 
-    for (lhs) |c, i| {
-        if (std.ascii.toLower(c) != std.ascii.toLower(rhs[i])) {
+    for (lhs, rhs) |l, r| {
+        if (std.ascii.toLower(l) != std.ascii.toLower(r)) {
             return false;
         }
     }
@@ -453,7 +453,7 @@ fn Renderer(comptime WriterType: type) type {
                 .expr => |expr| try self.renderApiConstantExpr(expr),
                 .version => |version| {
                     try self.writer.writeAll("makeApiVersion(");
-                    for (version) |part, i| {
+                    for (version, 0..) |part, i| {
                         if (i != 0) {
                             try self.writer.writeAll(", ");
                         }
@@ -884,7 +884,7 @@ fn Renderer(comptime WriterType: type) type {
                     }
                 }
 
-                for (flags_by_bitpos[0..bits.bitwidth]) |maybe_flag_name, bitpos| {
+                for (flags_by_bitpos[0..bits.bitwidth], 0..) |maybe_flag_name, bitpos| {
                     if (maybe_flag_name) |flag_name| {
                         const field_name = try extractBitflagFieldName(bitflag_name, flag_name);
                         try self.writeIdentifierWithCase(.snake, field_name);


### PR DESCRIPTION
Fixed code where ```0..``` needed to be added and improved code with the use of the multi for syntax where possible.