### PR TITLE
Fixed bug in shader output path

### DIFF
--- a/generator/build_integration.zig
+++ b/generator/build_integration.zig
@@ -170,12 +170,9 @@ pub const ShaderCompileStep = struct {
         var shaders_file_contents = std.ArrayList(u8).init(self.b.allocator);
         const shaders_out = shaders_file_contents.writer();
 
-        const shaders_dir = try self.b.build_root.join(
+        const shaders_dir = try self.b.cache_root.join(
             self.b.allocator,
-            &.{try self.b.cache_root.join(
-                self.b.allocator,
-                &.{cache_dir},
-            )},
+            &.{cache_dir},
         );
         try cwd.makePath(shaders_dir);
 


### PR DESCRIPTION
This PR fixes a bug in the calculation of the output path of the shaders, the cache root and build root where concataneted together resulting in nested full paths. If your where building vulkan zig at ```/home/name/vulkan-zig``` then the shader path would be ```/home/name/vulkan-zig/home/name/vulkan-zig/zig-cache/shaders```.