### PR TITLE
Update for zig build changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,6 @@ pub const ${name} align(@alignOf(u32)) = @embedFile("${path}").*;
 See [build.zig](build.zig) for a working example.
 
 ## Limitations
-* Currently, the self-hosted version of Zig's cache-hash API is not yet ready for usage, which means that the bindings are regenerated every time an executable is built.
-
 * vulkan-zig has as of yet no functionality for selecting feature levels and extensions when generating bindings. This is because when an extension is promoted to Vulkan core, its fields and commands are renamed to lose the extensions author tag (for example, VkSemaphoreWaitFlagsKHR was renamed to VkSemaphoreWaitFlags when it was promoted from an extension to Vulkan 1.2 core). This leads to inconsistencies when only items from up to a certain feature level is included, as these promoted items then need to re-gain a tag.
 
 ## Example

--- a/build.zig
+++ b/build.zig
@@ -62,7 +62,6 @@ pub fn build(b: *std.Build) void {
 
     const triangle_run_cmd = b.addRunArtifact(triangle_exe);
     triangle_run_cmd.step.dependOn(b.getInstallStep());
-    triangle_run_cmd.condition = .always;
 
     const triangle_run_step = b.step("run-triangle", "Run the triangle example");
     triangle_run_step.dependOn(&triangle_run_cmd.step);

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const vkgen = @import("generator/index.zig");
-const Step = std.build.Step;
 
 pub const ShaderCompileStep = vkgen.ShaderCompileStep;
 pub const VkGenerateStep = vkgen.VkGenerateStep;

--- a/generator/build_integration.zig
+++ b/generator/build_integration.zig
@@ -1,8 +1,5 @@
 const std = @import("std");
-const path = std.fs.path;
-const Builder = std.build.Builder;
-const Step = std.build.Step;
-const GeneratedFile = std.build.GeneratedFile;
+const Build = std.Build;
 
 /// Utility functionality to help with compiling shaders from build.zig.
 /// Invokes a shader compile command (e.g., glslc ...) for each shader
@@ -23,7 +20,7 @@ pub const ShaderCompileStep = struct {
 
         /// To ensure that if compilation options change, the shader is recompiled
         /// properly.
-        fn hash(self: ShaderOptions, b: *Builder, hasher: anytype) !void {
+        fn hash(self: ShaderOptions, b: *Build, hasher: anytype) !void {
             for (self.args) |arg| {
                 hasher.update(arg);
             }
@@ -59,8 +56,7 @@ pub const ShaderCompileStep = struct {
         options: ShaderOptions,
     };
 
-    step: Step,
-    b: *Builder,
+    step: Build.Step,
 
     /// The command and optional arguments used to invoke the shader compiler.
     compile_command: []const []const u8,
@@ -73,17 +69,21 @@ pub const ShaderCompileStep = struct {
 
     /// The main Zig file that contains all the shaders. Each shader is included as
     /// `pub const ${name} align(@alignOf(u32))= @embedFile("${path").*;`
-    generated_file: GeneratedFile,
+    generated_file: Build.GeneratedFile,
 
     /// Create a ShaderCompileStep for `builder`. When this step is invoked by the build
     /// system, `<compile_command...> <shader_source> <output_flag> <path>` is invoked for each shader.
     /// For example, if one calls this with `create(b, "glslc", "-o")` and then
     /// `c.addShader("vertex", "vertex.glsl", .{})`, the command will be `glslc vertex.glsl -o <path>`
-    pub fn create(builder: *Builder, compile_command: []const []const u8, output_flag: []const u8) *ShaderCompileStep {
+    pub fn create(builder: *Build, compile_command: []const []const u8, output_flag: []const u8) *ShaderCompileStep {
         const self = builder.allocator.create(ShaderCompileStep) catch unreachable;
         self.* = .{
-            .step = Step.init(.custom, "shaders", builder.allocator, make),
-            .b = builder,
+            .step = Build.Step.init(.{
+                .id = .custom,
+                .name = "shaders",
+                .owner = builder,
+                .makeFn = make,
+            }),
             .compile_command = builder.dupeStrings(compile_command),
             .output_flag = builder.dupe(output_flag),
             .shaders = std.ArrayList(Shader).init(builder.allocator),
@@ -94,14 +94,14 @@ pub const ShaderCompileStep = struct {
     }
 
     /// Returns the shaders module with name.
-    pub fn getModule(self: *ShaderCompileStep) *std.build.Module {
-        return self.b.createModule(.{
+    pub fn getModule(self: *ShaderCompileStep) *Build.Module {
+        return self.step.owner.createModule(.{
             .source_file = self.getSource(),
         });
     }
 
     /// Returns the file source for the generated shader resource code.
-    pub fn getSource(self: *ShaderCompileStep) std.build.FileSource {
+    pub fn getSource(self: *ShaderCompileStep) Build.FileSource {
         return .{ .generated = &self.generated_file };
     }
 
@@ -110,7 +110,8 @@ pub const ShaderCompileStep = struct {
     /// This path can then be used to include the binary into an executable, for example by passing it
     /// to @embedFile via an additional generated file.
     pub fn add(self: *ShaderCompileStep, name: []const u8, src: []const u8, options: ShaderOptions) void {
-        const full_source_path = self.b.build_root.join(self.b.allocator, &.{src}) catch unreachable;
+        const b = self.step.owner;
+        const full_source_path = b.build_root.join(b.allocator, &.{src}) catch unreachable;
         self.shaders.append(.{
             .name = name,
             .source_path = full_source_path,
@@ -120,8 +121,9 @@ pub const ShaderCompileStep = struct {
 
     /// Create a hash of a shader's source contents.
     fn hashShaderToFileName(self: *ShaderCompileStep, shader: Shader) ![64]u8 {
+        const b = self.step.owner;
         const source = std.fs.cwd().readFileAlloc(
-            self.b.allocator,
+            b.allocator,
             shader.source_path,
             std.math.maxInt(usize),
         ) catch |err| switch (err) {
@@ -140,7 +142,7 @@ pub const ShaderCompileStep = struct {
         hasher.update(source);
         // Not only the shader source must be the same to ensure uniqueness -
         // the compilation options must be the same as well!
-        try shader.options.hash(self.b, &hasher);
+        try shader.options.hash(b, &hasher);
         // And the compile command, too.
         for (self.compile_command) |cmd| {
             hasher.update(cmd);
@@ -159,26 +161,28 @@ pub const ShaderCompileStep = struct {
     }
 
     /// Internal build function.
-    fn make(step: *Step) !void {
+    fn make(step: *Build.Step, progress: *std.Progress.Node) !void {
+        _ = progress;
+        const b = step.owner;
         const self = @fieldParentPtr(ShaderCompileStep, "step", step);
         const cwd = std.fs.cwd();
 
-        var cmd = std.ArrayList([]const u8).init(self.b.allocator);
+        var cmd = std.ArrayList([]const u8).init(b.allocator);
         try cmd.appendSlice(self.compile_command);
         const base_cmd_len = cmd.items.len;
 
-        var shaders_file_contents = std.ArrayList(u8).init(self.b.allocator);
+        var shaders_file_contents = std.ArrayList(u8).init(b.allocator);
         const shaders_out = shaders_file_contents.writer();
 
-        const shaders_dir = try self.b.cache_root.join(
-            self.b.allocator,
+        const shaders_dir = try b.cache_root.join(
+            b.allocator,
             &.{cache_dir},
         );
         try cwd.makePath(shaders_dir);
 
         for (self.shaders.items) |shader| {
             const shader_basename = try self.hashShaderToFileName(shader);
-            const shader_out_path = try std.fs.path.join(self.b.allocator, &.{
+            const shader_out_path = try std.fs.path.join(b.allocator, &.{
                 shaders_dir,
                 &shader_basename,
             });
@@ -203,7 +207,7 @@ pub const ShaderCompileStep = struct {
 
             try cmd.appendSlice(shader.options.args);
             try cmd.appendSlice(&.{ shader.source_path, self.output_flag, shader_out_path });
-            try self.b.spawnChild(cmd.items);
+            try step.evalChildProcess(cmd.items);
         }
 
         // Generate a file name for the shaders zig source based on the contents of shaders_file_contents.
@@ -214,7 +218,7 @@ pub const ShaderCompileStep = struct {
         hasher.update(shaders_file_contents.items);
 
         const shaders_path = try std.fs.path.join(
-            self.b.allocator,
+            b.allocator,
             &.{ shaders_dir, &digest(&hasher) },
         );
 


### PR DESCRIPTION
- Step now holds the builder and some manifest/cache helpers
- cleaned up proxy names and remaining uses of `std.build`
- removed vicious lie from README
- the run condition was unnecessary (it was a bug workaround), and now also broken