### PR TITLE
Fixed deprecated install step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    generator_exe.install();
+    b.installArtifact(generator_exe);
 
     // or they can skip all that, and just make sure to pass `.registry = "path/to/vk.xml"` to `b.dependency`,
     // and then obtain the module directly via `.module("vulkan-zig")`.
@@ -42,7 +42,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    triangle_exe.install();
+    b.installArtifact(triangle_exe);
     triangle_exe.linkLibC();
     triangle_exe.linkSystemLibrary("glfw");
 


### PR DESCRIPTION
After attempting to build with the master branch of zig, there was an error indicating that `exe.install()` is deprecated.