### PR TITLE
Expose shader hash

### DIFF
--- a/generator/vulkan/build_integration.zig
+++ b/generator/vulkan/build_integration.zig
@@ -72,6 +72,7 @@ pub const GenerateStep = struct {
     /// by parsing it and rendering with `std.zig.parse` and `std.zig.render` respectively.
     fn make(step: *Build.Step, progress: *std.Progress.Node) !void {
         _ = progress;
+
         const b = step.owner;
         const self = @fieldParentPtr(GenerateStep, "step", step);
         const cwd = std.fs.cwd();


### PR DESCRIPTION
I'm not sure this is a desired patch, but I made this commit so that I can actually connect hashes to the original shader names. 
I use this to copy the shaders to an assets folder that the program is aware of with their original names. This is desired in my project because a shader can then be swapped by end users (not that there are any :D)

The downside is of course some substantial bloat per Shader