### PR TITLE
Fix outdated README "generation from build.zig" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pub fn build(b: *Builder) void {
     const exe = b.addExecutable("my-executable", "src/main.zig");
 
     // Create a step that generates vk.zig (stored in zig-cache) from the provided vulkan registry.
-    const gen = vkgen.VkGenerateStep.create(b, "path/to/vk.xml", "vk.zig");
+    const gen = vkgen.VkGenerateStep.create(b, "path/to/vk.xml");
 
     // Add the generated file as package to the final executable
     exe.addModule("vulkan", gen.getModule());


### PR DESCRIPTION
vulkan-zig accepts only 2 parameters now