### PR TITLE
Nullable pointer parameters

### DIFF
--- a/generator/vulkan/c_parse.zig
+++ b/generator/vulkan/c_parse.zig
@@ -449,6 +449,7 @@ fn parseFnPtrSuffix(allocator: Allocator, xctok: *XmlCTokenizer, return_type: Ty
         .name = first_param.name.?,
         .param_type = first_param.decl_type,
         .is_buffer_len = false,
+        .is_optional = false,
     });
 
     while (true) {
@@ -463,6 +464,7 @@ fn parseFnPtrSuffix(allocator: Allocator, xctok: *XmlCTokenizer, return_type: Ty
             .name = decl.name orelse return error.MissingTypeIdentifier,
             .param_type = decl.decl_type,
             .is_buffer_len = false,
+            .is_optional = false,
         });
     }
 

--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -278,7 +278,7 @@ fn lenToPointer(fields: Fields, len: []const u8) std.meta.Tuple(&.{ registry.Poi
             for (params) |*param| {
                 if (mem.eql(u8, param.name, len)) {
                     param.is_buffer_len = true;
-                    return .{ .{ .other_field = param.name }, false };
+                    return .{ .{ .other_field = param.name }, param.is_optional };
                 }
             }
         },
@@ -499,7 +499,18 @@ fn parseCommand(allocator: Allocator, elem: *xml.Element, api: registry.Api) !re
             .name = decl.name,
             .param_type = decl.decl_type.typedef,
             .is_buffer_len = false,
+            .is_optional = false,
         };
+
+        if (param.getAttribute("optional")) |optionals| {
+            var optional_it = mem.split(u8, optionals, ",");
+            if (optional_it.next()) |first_optional| {
+                params[i].is_optional = mem.eql(u8, first_optional, "true");
+            } else {
+                // Optional is empty, probably incorrect.
+                return error.InvalidRegistry;
+            }
+        }
         i += 1;
     }
 

--- a/generator/vulkan/registry.zig
+++ b/generator/vulkan/registry.zig
@@ -111,6 +111,7 @@ pub const Command = struct {
         name: []const u8,
         param_type: TypeInfo,
         is_buffer_len: bool,
+        is_optional: bool,
     };
 
     params: []Param,


### PR DESCRIPTION
For procedure parameters which are of pointer type: if the associated `count` parameter is marked `optional` in the XML, this commit makes the parameter pointer type nullable.

Effectively, parameters of type `[*]` are now `?[*]` if the spec allows their associated `count` parameter to be 0.

This had already been implemented for struct members. This code is pretty much the same.

Resolves #40.