### PR TITLE
Fix `optional` detection conflict

### DIFF
--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -334,7 +334,7 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
         var it = mem.split(u8, optionals, ",");
         var current_type_info = type_info;
         while (current_type_info.* == .pointer) {
-            if (it.next()) |current_optional| {
+            if (it.next()) |optional_str| {
 
                 // The pointer may have already been marked as optional due to its `len` attribute.
                 var is_already_optional = false;
@@ -342,7 +342,7 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
                     is_already_optional = current_type_info.pointer.is_optional;
 
                 current_type_info.pointer.is_optional =
-                     is_already_optional or mem.eql(u8, current_optional, "true");
+                     is_already_optional or mem.eql(u8, optional_str, "true");
 
             } else {
                 // There is no information for this pointer, probably incorrect.

--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -300,6 +300,9 @@ fn lenToPointer(fields: Fields, len: []const u8) std.meta.Tuple(&.{ registry.Poi
 }
 
 fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.Element) !void {
+
+    var len_attribute_depth: usize = 0;
+
     if (elem.getAttribute("len")) |lens| {
         var it = mem.split(u8, lens, ",");
         var current_type_info = type_info;
@@ -311,7 +314,9 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
                 break :blk size_optional[0];
             } else .many;
             current_type_info.pointer.size = size;
+
             current_type_info = current_type_info.pointer.child;
+            len_attribute_depth += 1;
         }
 
         if (it.next()) |_| {
@@ -322,18 +327,30 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
         }
     }
 
+
+    var current_depth: usize = 0;
+
     if (elem.getAttribute("optional")) |optionals| {
         var it = mem.split(u8, optionals, ",");
         var current_type_info = type_info;
         while (current_type_info.* == .pointer) {
             if (it.next()) |current_optional| {
-                current_type_info.pointer.is_optional = mem.eql(u8, current_optional, "true");
+
+                // The pointer may have already been marked as optional due to its `len` attribute.
+                var is_already_optional = false;
+                if (current_depth < len_attribute_depth)
+                    is_already_optional = current_type_info.pointer.is_optional;
+
+                current_type_info.pointer.is_optional =
+                     is_already_optional or mem.eql(u8, current_optional, "true");
+
             } else {
                 // There is no information for this pointer, probably incorrect.
                 return error.InvalidRegistry;
             }
 
             current_type_info = current_type_info.pointer.child;
+            current_depth += 1;
         }
     }
 }


### PR DESCRIPTION
Resolves #100.

This is the entire difference in the generated Zig code:
```diff
@@ -1107,11 +1107,11 @@
 pub const PipelineLayoutCreateInfo = extern struct {
     s_type: StructureType = .pipeline_layout_create_info,
     p_next: ?*const anyopaque = null,
     flags: PipelineLayoutCreateFlags = .{},
     set_layout_count: u32 = 0,
-    p_set_layouts: [*]const DescriptorSetLayout,
+    p_set_layouts: ?[*]const DescriptorSetLayout = null,
     push_constant_range_count: u32 = 0,
     p_push_constant_ranges: ?[*]const PushConstantRange = null,
 };
@@ -3281,11 +3281,11 @@
 pub const DescriptorSetLayoutBindingFlagsCreateInfo = extern struct {
     s_type: StructureType = .descriptor_set_layout_binding_flags_create_info,
     p_next: ?*const anyopaque = null,
     binding_count: u32 = 0,
-    p_binding_flags: [*]const DescriptorBindingFlags,
+    p_binding_flags: ?[*]const DescriptorBindingFlags = null,
 };
```