### PR TITLE
Format flags

### DIFF
--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -49,6 +49,7 @@ const preamble =
     \\        pub fn contains(lhs: FlagsType, rhs: FlagsType) bool {
     \\            return toInt(intersect(lhs, rhs)) == toInt(rhs);
     \\        }
+++ bit_flag_format ++
     \\    };
     \\}
     \\pub fn makeApiVersion(variant: u3, major: u7, minor: u10, patch: u12) u32 {
@@ -67,6 +68,31 @@ const preamble =
     \\    return @truncate(u12, version);
     \\}
     \\
+;
+
+const bit_flag_format =
+    \\        pub fn format(
+    \\            self: @This(),
+    \\            comptime _: []const u8,
+    \\            _: std.fmt.FormatOptions,
+    \\            writer: anytype,
+    \\        ) !void {
+    \\            try writer.writeAll(@typeName(@This()) ++ "{");
+    \\            var first = true;
+    \\            inline for (comptime std.meta.fieldNames(@This())) |name| {
+    \\                if (name[0] == '_') continue;
+    \\                if (@field(self, name)) {
+    \\                    if (first) {
+    \\                        try writer.writeAll(" " ++ name);
+    \\                        first = false;
+    \\                    } else {
+    \\                        try writer.writeAll(", " ++ name);
+    \\                    }
+    \\                }
+    \\            }
+    \\            if (!first) try writer.writeAll(" ");
+    \\            try writer.writeAll("}");
+    \\        }
 ;
 
 const builtin_types = std.ComptimeStringMap([]const u8, .{
@@ -1060,6 +1086,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\            }
                 \\            return true;
                 \\        }
+            ++ bit_flag_format ++
                 \\    };
                 \\}
                 \\

--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -66,10 +66,10 @@ const preamble =
     \\                if (name[0] == '_') continue;
     \\                if (@field(self, name)) {
     \\                    if (first) {
-    \\                        try writer.writeAll(" " ++ name);
+    \\                        try writer.writeAll(" ." ++ name);
     \\                        first = false;
     \\                    } else {
-    \\                        try writer.writeAll(", " ++ name);
+    \\                        try writer.writeAll(", ." ++ name);
     \\                    }
     \\                }
     \\            }

--- a/generator/vulkan/render.zig
+++ b/generator/vulkan/render.zig
@@ -49,7 +49,33 @@ const preamble =
     \\        pub fn contains(lhs: FlagsType, rhs: FlagsType) bool {
     \\            return toInt(intersect(lhs, rhs)) == toInt(rhs);
     \\        }
-++ bit_flag_format ++
+    \\        pub usingnamespace FlagFormatMixin(FlagsType);
+    \\    };
+    \\}
+    \\fn FlagFormatMixin(comptime FlagsType: type) type {
+    \\    return struct {
+    \\        pub fn format(
+    \\            self: FlagsType,
+    \\            comptime _: []const u8,
+    \\            _: std.fmt.FormatOptions,
+    \\            writer: anytype,
+    \\        ) !void {
+    \\            try writer.writeAll(@typeName(FlagsType) ++ "{");
+    \\            var first = true;
+    \\            inline for (comptime std.meta.fieldNames(FlagsType)) |name| {
+    \\                if (name[0] == '_') continue;
+    \\                if (@field(self, name)) {
+    \\                    if (first) {
+    \\                        try writer.writeAll(" " ++ name);
+    \\                        first = false;
+    \\                    } else {
+    \\                        try writer.writeAll(", " ++ name);
+    \\                    }
+    \\                }
+    \\            }
+    \\            if (!first) try writer.writeAll(" ");
+    \\            try writer.writeAll("}");
+    \\        }
     \\    };
     \\}
     \\pub fn makeApiVersion(variant: u3, major: u7, minor: u10, patch: u12) u32 {
@@ -68,31 +94,6 @@ const preamble =
     \\    return @truncate(u12, version);
     \\}
     \\
-;
-
-const bit_flag_format =
-    \\        pub fn format(
-    \\            self: @This(),
-    \\            comptime _: []const u8,
-    \\            _: std.fmt.FormatOptions,
-    \\            writer: anytype,
-    \\        ) !void {
-    \\            try writer.writeAll(@typeName(@This()) ++ "{");
-    \\            var first = true;
-    \\            inline for (comptime std.meta.fieldNames(@This())) |name| {
-    \\                if (name[0] == '_') continue;
-    \\                if (@field(self, name)) {
-    \\                    if (first) {
-    \\                        try writer.writeAll(" " ++ name);
-    \\                        first = false;
-    \\                    } else {
-    \\                        try writer.writeAll(", " ++ name);
-    \\                    }
-    \\                }
-    \\            }
-    \\            if (!first) try writer.writeAll(" ");
-    \\            try writer.writeAll("}");
-    \\        }
 ;
 
 const builtin_types = std.ComptimeStringMap([]const u8, .{
@@ -1086,7 +1087,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\            }
                 \\            return true;
                 \\        }
-            ++ bit_flag_format ++
+                \\        pub usingnamespace FlagFormatMixin(CommandFlags);
                 \\    };
                 \\}
                 \\


### PR DESCRIPTION
This changes to format output from:

    MyFlagType{ .first_bit = true, second_bit = false, _reserved_bit_0 = false, _reserved_bit_1 = false }

to the following:

    MyFlagType{ .first_bit }

That is, we only show bits which are `true`, which reduces noise when logging values.