### PR TITLE
Update "Shader compilation" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,27 +288,35 @@ pub const xcb_connection_t = if (@hasDecl(root, "xcb_connection_t")) root.xcb_co
 For some times (such as those from Google Games Platform) no default is known. Usage of these without providing a concrete type in the project root generates a compile error.
 
 ### Shader compilation
-vulkan-zig provides functionality to help compiling shaders to spir-v using glslc. It can be used from build.zig as follows:
+
+vulkan-zig provides functionality to help compile shaders to SPIR-V using glslc.
+It can be used from build.zig as follows:
 
 ```zig
-const vkgen = @import("vulkan-zig/generator/index.zig");
+const vkgen = @import("vulkan_zig");
 
 pub fn build(b: *Builder) void {
     ...
-    const exe = b.addExecutable("my-executable", "src/main.zig");
-
-    const gen = vkgen.VkGenerateStep(b, "path/to/vk.xml", "vk.zig");
-    exe.addPackage(gen.package);
-
     const shader_comp = vkgen.ShaderCompileStep.create(
         builder,
-        &[_][]const u8{"glslc", "--target-env=vulkan1.2"}, // Path to glslc and additional parameters
+        &[_][]const u8{"glslc", "--target-env=vulkan1.2"},
+        "-o", 
     );
-    exe.addPackage(shader_comp.getPackage("shaders"));
-    shader_comp.add("shader", "path/to/shader.frag", .{});
+    shader_comp.add("shader_frag", "path/to/shader.frag", .{});
+    shader_comp.add("shader_vert", "path/to/shader.vert", .{});
+    exe.addModule("shaders", shader_comp.getModule());
 }
 ```
-Upon compilation, glslc is then invoked to compile each shader, and the result is placed within `zig-cache`. All shaders which are compiled using a particular `ShaderCompileStep` are imported in a single Zig file using `@embedFile`, and this file can be added to an executable as a package using `getPackage`. To slightly improve compile times, shader compilation is cached; as long as a shader's source and its compile commands stay the same, the shader is not recompiled. The spir-v code for any particular shader is aligned to that of a 32-bit integer as follows, as required by vkCreateShaderModule:
+
+Upon compilation, glslc is invoked to compile each shader, and the result is
+placed within `zig-cache`. All shaders which are compiled using a particular
+`ShaderCompileStep` are imported in a single Zig file using `@embedFile`, and
+this file can be added to an executable as a module using `addModule`. To
+slightly improve compile times, shader compilation is cached; as long as a
+shader's source and its compile commands stay the same, the shader is not
+recompiled. The SPIR-V code for any particular shader is aligned to that of a
+32-bit integer as follows, as required by vkCreateShaderModule:
+
 ```zig
 pub const ${name} align(@alignOf(u32)) = @embedFile("${path}").*;
 ```


### PR DESCRIPTION
The example was a bit outdated:

* Used the "package" terminology which has been replaced by "module"
* The import didn't work for me
* Missing parameter from ShaderCompileStep.create()

Side note: I don't really understand the purpose of the output flag parameter. What else can it be other than "-o"?

Side note 2: I'm new to Zig, and for some reason the alignment stuff doesn't work for me. I have to use the compiled shaders with `@ptrCast(@alignCast(&my_shader))`; the `@as([*]const u32, @ptrCast(&my_shader))` approach doesn't work. If I knew the right way to do this, I would have included it in the example snippet.