### PR TITLE
get rid of build steps

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const vkgen = @import("generator/index.zig");
 
 pub const ShaderCompileStep = vkgen.ShaderCompileStep;
-pub const VkGenerateStep = vkgen.VkGenerateStep;
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -74,12 +73,13 @@ pub fn build(b: *std.Build) void {
     const triangle_run_step = b.step("run-triangle", "Run the triangle example");
     triangle_run_step.dependOn(&triangle_run_cmd.step);
 
-    var test_target = b.addTest(.{
+    const test_step = b.step("test", "Run all the tests");
+
+    const tests = b.addTest(.{
         .root_source_file = .{ .path = "generator/index.zig" },
     });
-
-    var test_step = b.step("test", "Run all the tests");
-    test_step.dependOn(&test_target.step);
+    const run_tests = b.addRunArtifact(tests);
+    test_step.dependOn(&run_tests.step);
 
     // This test needs to be an object so that vulkan-zig can import types from the root.
     // It does not need to run anyway.
@@ -89,7 +89,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-
     ref_all_decls_test.root_module.addImport("vulkan", example_vk);
     test_step.dependOn(&ref_all_decls_test.step);
 }

--- a/generator/main.zig
+++ b/generator/main.zig
@@ -1,23 +1,19 @@
 const std = @import("std");
 const generator = @import("vulkan/generator.zig");
 
-const usage =
-    \\Usage: {s} [options] <spec xml path> <output zig source>
-    \\Options:
-    \\-h --help        show this message and exit.
-    \\-a --api <api>   Generate API for 'vulkan' or 'vulkansc'. Defaults to 'vulkan'.
-    \\
-;
+fn invalidUsage(prog_name: []const u8, comptime fmt: []const u8, args: anytype) noreturn {
+    std.log.err(fmt, args);
+    std.log.err("see {s} --help for usage", .{prog_name});
+    std.process.exit(1);
+}
 
-pub fn main() !void {
-    const stderr = std.io.getStdErr();
-
+pub fn main() void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
     var args = try std.process.argsWithAllocator(allocator);
-    const prog_name = args.next() orelse return error.ExecutableNameMissing;
+    const prog_name = args.next() orelse "vulkan-zig-generator";
 
     var maybe_xml_path: ?[]const u8 = null;
     var maybe_out_path: ?[]const u8 = null;
@@ -26,7 +22,7 @@ pub fn main() !void {
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             @setEvalBranchQuota(2000);
-            try stderr.writer().print(
+            std.io.getStdOut().writer().print(
                 \\Utility to generate a Zig binding from the Vulkan XML API registry.
                 \\
                 \\The most recent Vulkan XML API registry can be obtained from
@@ -34,64 +30,98 @@ pub fn main() !void {
                 \\and the most recent LunarG Vulkan SDK version can be found at
                 \\$VULKAN_SDK/x86_64/share/vulkan/registry/vk.xml.
                 \\
+                \\Usage: {s} [options] <spec xml path> <output zig source>
+                \\Options:
+                \\-h --help        show this message and exit.
+                \\-a --api <api>   Generate API for 'vulkan' or 'vulkansc'. Defaults to 'vulkan'.
                 \\
-                ++ usage,
+            ,
                 .{prog_name},
-            );
+            ) catch |err| {
+                std.log.err("failed to write to stdout: {s}", .{@errorName(err)});
+                std.process.exit(1);
+            };
             return;
         } else if (std.mem.eql(u8, arg, "-a") or std.mem.eql(u8, arg, "--api")) {
             const api_str = args.next() orelse {
-                try stderr.writer().print("Error: {s} expects argument <api>\n", .{arg});
-                return;
+                invalidUsage(prog_name, "{s} expects argument <api>", .{arg});
             };
             api = std.meta.stringToEnum(generator.Api, api_str) orelse {
-                try stderr.writer().print("Error: Invalid api '{s}'", .{api_str});
-                return;
+                invalidUsage(prog_name, "invalid api '{s}'", .{api_str});
             };
         } else if (maybe_xml_path == null) {
             maybe_xml_path = arg;
         } else if (maybe_out_path == null) {
             maybe_out_path = arg;
         } else {
-            try stderr.writer().print("Error: Superficial argument '{s}'\n", .{arg});
-            return;
+            invalidUsage(prog_name, "superficial argument '{s}'", .{arg});
         }
     }
 
     const xml_path = maybe_xml_path orelse {
-        try stderr.writer().print("Error: Missing required argument <spec xml path>\n" ++ usage, .{prog_name});
-        return;
+        invalidUsage(prog_name, "missing required argument <spec xml path>", .{});
     };
 
     const out_path = maybe_out_path orelse {
-        try stderr.writer().print("Error: Missing required argument <output zig source>\n" ++ usage, .{prog_name});
-        return;
+        invalidUsage(prog_name, "missing required argument <output zig source>", .{});
     };
 
     const cwd = std.fs.cwd();
     const xml_src = cwd.readFileAlloc(allocator, xml_path, std.math.maxInt(usize)) catch |err| {
-        try stderr.writer().print("Error: Failed to open input file '{s}' ({s})\n", .{ xml_path, @errorName(err) });
-        return;
+        std.log.err("failed to open input file '{s}' ({s})", .{ xml_path, @errorName(err) });
+        std.process.exit(1);
     };
 
     var out_buffer = std.ArrayList(u8).init(allocator);
-    try generator.generate(allocator, api, xml_src, out_buffer.writer());
-    try out_buffer.append(0);
+    generator.generate(allocator, api, xml_src, out_buffer.writer()) catch |err| switch (err) {
+        error.InvalidXml => {
+            std.log.err("invalid vulkan registry - invalid xml", .{});
+            std.log.err("please check that the correct vk.xml file is passed", .{});
+            std.process.exit(1);
+        },
+        error.InvalidRegistry => {
+            std.log.err("invalid vulkan registry - registry is valid xml but contents are invalid", .{});
+            std.log.err("please check that the correct vk.xml file is passed", .{});
+            std.process.exit(1);
+        },
+        error.UnhandledBitfieldStruct => {
+            std.log.err("unhandled struct with bit fields detected in vk.xml", .{});
+            std.log.err("this is a bug in vulkan-zig", .{});
+            std.log.err("please make a bug report at https://github.com/Snektron/vulkan-zig/issues/", .{});
+            std.process.exit(1);
+        },
+        error.OutOfMemory => @panic("oom"),
+    };
+
+    out_buffer.append(0) catch @panic("oom");
 
     const src = out_buffer.items[0 .. out_buffer.items.len - 1 :0];
-    const tree = try std.zig.Ast.parse(allocator, src, .zig);
-    const formatted = try tree.render(allocator);
+    const tree = std.zig.Ast.parse(allocator, src, .zig) catch |err| switch (err) {
+        error.OutOfMemory => @panic("oom"),
+    };
+
+    if (tree.errors.len > 0) {
+        std.log.err("generated invalid zig code", .{});
+        std.log.err("this is a bug in vulkan-zig", .{});
+        std.log.err("please make a bug report at https://github.com/Snektron/vulkan-zig/issues/", .{});
+
+        std.process.exit(1);
+    }
+
+    const formatted = tree.render(allocator) catch |err| switch (err) {
+        error.OutOfMemory => @panic("oom"),
+    };
     defer allocator.free(formatted);
 
     if (std.fs.path.dirname(out_path)) |dir| {
         cwd.makePath(dir) catch |err| {
-            try stderr.writer().print("Error: Failed to create output directory '{s}' ({s})\n", .{ dir, @errorName(err) });
-            return;
+            std.log.err("failed to create output directory '{s}' ({s})", .{ dir, @errorName(err) });
+            std.process.exit(1);
         };
     }
 
     cwd.writeFile(out_path, formatted) catch |err| {
-        try stderr.writer().print("Error: Failed to write to output file '{s}' ({s})\n", .{ out_path, @errorName(err) });
-        return;
+        std.log.err("failed to write to output file '{s}' ({s})", .{ out_path, @errorName(err) });
+        std.process.exit(1);
     };
 }

--- a/generator/main.zig
+++ b/generator/main.zig
@@ -7,6 +7,21 @@ fn invalidUsage(prog_name: []const u8, comptime fmt: []const u8, args: anytype) 
     std.process.exit(1);
 }
 
+fn reportParseErrors(tree: std.zig.Ast) !void {
+    const stderr = std.io.getStdErr().writer();
+
+    for (tree.errors) |err| {
+        const loc = tree.tokenLocation(0, err.token);
+        try stderr.print("(vulkan-zig error):{}:{}: error: ", .{ loc.line + 1, loc.column + 1 });
+        try tree.renderError(err, stderr);
+        try stderr.print("\n{s}\n", .{tree.source[loc.line_start..loc.line_end]});
+        for (0..loc.column) |_| {
+            try stderr.writeAll(" ");
+        }
+        try stderr.writeAll("^\n");
+    }
+}
+
 pub fn main() void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -17,6 +32,7 @@ pub fn main() void {
 
     var maybe_xml_path: ?[]const u8 = null;
     var maybe_out_path: ?[]const u8 = null;
+    var debug: bool = false;
     var api = generator.Api.vulkan;
 
     while (args.next()) |arg| {
@@ -34,6 +50,7 @@ pub fn main() void {
                 \\Options:
                 \\-h --help        show this message and exit.
                 \\-a --api <api>   Generate API for 'vulkan' or 'vulkansc'. Defaults to 'vulkan'.
+                \\--debug          Write out unformatted source if does not parse correctly.
                 \\
             ,
                 .{prog_name},
@@ -49,6 +66,8 @@ pub fn main() void {
             api = std.meta.stringToEnum(generator.Api, api_str) orelse {
                 invalidUsage(prog_name, "invalid api '{s}'", .{api_str});
             };
+        } else if (std.mem.eql(u8, arg, "--debug")) {
+            debug = true;
         } else if (maybe_xml_path == null) {
             maybe_xml_path = arg;
         } else if (maybe_out_path == null) {
@@ -100,18 +119,24 @@ pub fn main() void {
         error.OutOfMemory => @panic("oom"),
     };
 
-    if (tree.errors.len > 0) {
+    const formatted = if (tree.errors.len > 0) blk: {
         std.log.err("generated invalid zig code", .{});
         std.log.err("this is a bug in vulkan-zig", .{});
         std.log.err("please make a bug report at https://github.com/Snektron/vulkan-zig/issues/", .{});
+        std.log.err("or run with --debug to write out unformatted source", .{});
 
+        reportParseErrors(tree) catch |err| {
+            std.log.err("failed to dump ast errors: {s}", .{@errorName(err)});
+            std.process.exit(1);
+        };
+
+        if (debug) {
+            break :blk src;
+        }
         std.process.exit(1);
-    }
-
-    const formatted = tree.render(allocator) catch |err| switch (err) {
+    } else tree.render(allocator) catch |err| switch (err) {
         error.OutOfMemory => @panic("oom"),
     };
-    defer allocator.free(formatted);
 
     if (std.fs.path.dirname(out_path)) |dir| {
         cwd.makePath(dir) catch |err| {

--- a/generator/vulkan/parse.zig
+++ b/generator/vulkan/parse.zig
@@ -300,7 +300,6 @@ fn lenToPointer(fields: Fields, len: []const u8) std.meta.Tuple(&.{ registry.Poi
 }
 
 fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.Element) !void {
-
     var len_attribute_depth: usize = 0;
 
     if (elem.getAttribute("len")) |lens| {
@@ -327,7 +326,6 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
         }
     }
 
-
     var current_depth: usize = 0;
 
     if (elem.getAttribute("optional")) |optionals| {
@@ -342,8 +340,7 @@ fn parsePointerMeta(fields: Fields, type_info: *registry.TypeInfo, elem: *xml.El
                     is_already_optional = current_type_info.pointer.is_optional;
 
                 current_type_info.pointer.is_optional =
-                     is_already_optional or mem.eql(u8, optional_str, "true");
-
+                    is_already_optional or mem.eql(u8, optional_str, "true");
             } else {
                 // There is no information for this pointer, probably incorrect.
                 // Currently there is one definition where this is the case, VkCudaLaunchInfoNV.


### PR DESCRIPTION
It seems these are not the right way to go anymore. Currently, there is already the alternative route of creating a run step from `b.dependency("vulkan-zig").artifact("generator")`. I think going forward, this should be the preferred method, or at least some variation where vk.zig is generated by a tool that is compiled and executed by the build system rather than implementing a custom step. This means that this change is mainly about removing the old `VkGenerateStep` and `ShaderCompileSteps`.