### PR TITLE
Compile on Zig master

### DIFF
--- a/generator/vulkan/build_integration.zig
+++ b/generator/vulkan/build_integration.zig
@@ -77,7 +77,7 @@ pub const GenerateStep = struct {
         const self = @fieldParentPtr(GenerateStep, "step", step);
         const cwd = std.fs.cwd();
 
-        var man = b.cache.obtain();
+        var man = b.graph.cache.obtain();
         defer man.deinit();
 
         const spec = try cwd.readFileAlloc(b.allocator, self.spec_path, std.math.maxInt(usize));


### PR DESCRIPTION
Build `Cache` was moved from `std.Build` to `std.Build.Graph`.