### PR TITLE
remove no longer used error from set

### DIFF
--- a/generator/main.zig
+++ b/generator/main.zig
@@ -14,7 +14,6 @@ pub fn main() void {
 
     var args = std.process.argsWithAllocator(allocator) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM"),
-        error.InvalidCmdLine => @panic("Invalid command line"),
     };
     const prog_name = args.next() orelse "vulkan-zig-generator";
 


### PR DESCRIPTION
The `InvalidCmdLine` error got removed from `argsWithAllocator` error set on master