### PR TITLE
update to 0.14.0-dev.91+a154d8da8

### DIFF
--- a/src/build_integration.zig
+++ b/src/build_integration.zig
@@ -211,7 +211,7 @@ pub const ShaderCompileStep = struct {
 
             try cmd.appendSlice(shader.options.args);
             try cmd.appendSlice(&.{ shader.source_path, self.output_flag, shader_out_path });
-            try step.evalChildProcess(cmd.items);
+            _ = try step.evalChildProcess(cmd.items);
         }
 
         // Generate a file name for the shaders zig source based on the contents of shaders_file_contents.


### PR DESCRIPTION
I am not sure, if the output of the child process should be used or not, but this change lets it compile again.