### PR TITLE
Array function wrappers

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -196,13 +196,8 @@ fn pickPhysicalDevice(
     allocator: Allocator,
     surface: vk.SurfaceKHR,
 ) !DeviceCandidate {
-    var device_count: u32 = undefined;
-    _ = try instance.enumeratePhysicalDevices(&device_count, null);
-
-    const pdevs = try allocator.alloc(vk.PhysicalDevice, device_count);
+    const pdevs = try instance.enumeratePhysicalDevicesAlloc(allocator);
     defer allocator.free(pdevs);
-
-    _ = try instance.enumeratePhysicalDevices(&device_count, pdevs.ptr);
 
     for (pdevs) |pdev| {
         if (try checkSuitable(instance, pdev, allocator, surface)) |candidate| {
@@ -240,12 +235,8 @@ fn checkSuitable(
 }
 
 fn allocateQueues(instance: Instance, pdev: vk.PhysicalDevice, allocator: Allocator, surface: vk.SurfaceKHR) !?QueueAllocation {
-    var family_count: u32 = undefined;
-    instance.getPhysicalDeviceQueueFamilyProperties(pdev, &family_count, null);
-
-    const families = try allocator.alloc(vk.QueueFamilyProperties, family_count);
+    const families = try instance.getPhysicalDeviceQueueFamilyPropertiesAlloc(pdev, allocator);
     defer allocator.free(families);
-    instance.getPhysicalDeviceQueueFamilyProperties(pdev, &family_count, families.ptr);
 
     var graphics_family: ?u32 = null;
     var present_family: ?u32 = null;
@@ -287,13 +278,8 @@ fn checkExtensionSupport(
     pdev: vk.PhysicalDevice,
     allocator: Allocator,
 ) !bool {
-    var count: u32 = undefined;
-    _ = try instance.enumerateDeviceExtensionProperties(pdev, null, &count, null);
-
-    const propsv = try allocator.alloc(vk.ExtensionProperties, count);
+    const propsv = try instance.enumerateDeviceExtensionPropertiesAlloc(pdev, null, allocator);
     defer allocator.free(propsv);
-
-    _ = try instance.enumerateDeviceExtensionProperties(pdev, null, &count, propsv.ptr);
 
     for (required_device_extensions) |ext| {
         for (propsv) |props| {

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -247,13 +247,10 @@ const SwapImage = struct {
 };
 
 fn initSwapchainImages(gc: *const GraphicsContext, swapchain: vk.SwapchainKHR, format: vk.Format, allocator: Allocator) ![]SwapImage {
-    var count: u32 = undefined;
-    _ = try gc.dev.getSwapchainImagesKHR(swapchain, &count, null);
-    const images = try allocator.alloc(vk.Image, count);
+    const images = try gc.dev.getSwapchainImagesKhrAlloc(swapchain, allocator);
     defer allocator.free(images);
-    _ = try gc.dev.getSwapchainImagesKHR(swapchain, &count, images.ptr);
 
-    const swap_images = try allocator.alloc(SwapImage, count);
+    const swap_images = try allocator.alloc(SwapImage, images.len);
     errdefer allocator.free(swap_images);
 
     var i: usize = 0;
@@ -273,11 +270,8 @@ fn findSurfaceFormat(gc: *const GraphicsContext, allocator: Allocator) !vk.Surfa
         .color_space = .srgb_nonlinear_khr,
     };
 
-    var count: u32 = undefined;
-    _ = try gc.instance.getPhysicalDeviceSurfaceFormatsKHR(gc.pdev, gc.surface, &count, null);
-    const surface_formats = try allocator.alloc(vk.SurfaceFormatKHR, count);
+    const surface_formats = try gc.instance.getPhysicalDeviceSurfaceFormatsKhrAlloc(gc.pdev, gc.surface, allocator);
     defer allocator.free(surface_formats);
-    _ = try gc.instance.getPhysicalDeviceSurfaceFormatsKHR(gc.pdev, gc.surface, &count, surface_formats.ptr);
 
     for (surface_formats) |sfmt| {
         if (std.meta.eql(sfmt, preferred)) {
@@ -289,11 +283,8 @@ fn findSurfaceFormat(gc: *const GraphicsContext, allocator: Allocator) !vk.Surfa
 }
 
 fn findPresentMode(gc: *const GraphicsContext, allocator: Allocator) !vk.PresentModeKHR {
-    var count: u32 = undefined;
-    _ = try gc.instance.getPhysicalDeviceSurfacePresentModesKHR(gc.pdev, gc.surface, &count, null);
-    const present_modes = try allocator.alloc(vk.PresentModeKHR, count);
+    const present_modes = try gc.instance.getPhysicalDeviceSurfacePresentModesKhrAlloc(gc.pdev, gc.surface, allocator);
     defer allocator.free(present_modes);
-    _ = try gc.instance.getPhysicalDeviceSurfacePresentModesKHR(gc.pdev, gc.surface, &count, present_modes.ptr);
 
     const preferred = [_]vk.PresentModeKHR{
         .mailbox_khr,

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -247,7 +247,7 @@ const SwapImage = struct {
 };
 
 fn initSwapchainImages(gc: *const GraphicsContext, swapchain: vk.SwapchainKHR, format: vk.Format, allocator: Allocator) ![]SwapImage {
-    const images = try gc.dev.getSwapchainImagesKhrAlloc(swapchain, allocator);
+    const images = try gc.dev.getSwapchainImagesAllocKHR(swapchain, allocator);
     defer allocator.free(images);
 
     const swap_images = try allocator.alloc(SwapImage, images.len);
@@ -270,7 +270,7 @@ fn findSurfaceFormat(gc: *const GraphicsContext, allocator: Allocator) !vk.Surfa
         .color_space = .srgb_nonlinear_khr,
     };
 
-    const surface_formats = try gc.instance.getPhysicalDeviceSurfaceFormatsKhrAlloc(gc.pdev, gc.surface, allocator);
+    const surface_formats = try gc.instance.getPhysicalDeviceSurfaceFormatsAllocKHR(gc.pdev, gc.surface, allocator);
     defer allocator.free(surface_formats);
 
     for (surface_formats) |sfmt| {
@@ -283,7 +283,7 @@ fn findSurfaceFormat(gc: *const GraphicsContext, allocator: Allocator) !vk.Surfa
 }
 
 fn findPresentMode(gc: *const GraphicsContext, allocator: Allocator) !vk.PresentModeKHR {
-    const present_modes = try gc.instance.getPhysicalDeviceSurfacePresentModesKhrAlloc(gc.pdev, gc.surface, allocator);
+    const present_modes = try gc.instance.getPhysicalDeviceSurfacePresentModesAllocKHR(gc.pdev, gc.surface, allocator);
     defer allocator.free(present_modes);
 
     const preferred = [_]vk.PresentModeKHR{

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -197,6 +197,10 @@ const enumerate_functions = std.StaticStringMap(void).initComptime(.{
     .{"vkEnumerateInstanceExtensionProperties"},
     .{"vkEnumeratePhysicalDevices"},
     .{"vkGetPhysicalDeviceQueueFamilyProperties"},
+    .{"vkGetPhysicalDeviceSurfaceFormatsKHR"},
+    .{"vkGetPhysicalDeviceSurfacePresentModesKHR"},
+    .{"vkEnumerateDeviceExtensionProperties"},
+    .{"vkGetSwapchainImagesKHR"},
 });
 
 // Given one of the above commands, returns the type of the array elements

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -194,13 +194,30 @@ const dispatch_override_functions = std.StaticStringMap(CommandDispatchType).ini
 
 // Functions that return an array of objects via a count and data pointer.
 const enumerate_functions = std.StaticStringMap(void).initComptime(.{
-    .{"vkEnumerateInstanceExtensionProperties"},
     .{"vkEnumeratePhysicalDevices"},
+    .{"vkEnumeratePhysicalDeviceGroups"},
     .{"vkGetPhysicalDeviceQueueFamilyProperties"},
-    .{"vkGetPhysicalDeviceSurfaceFormatsKHR"},
-    .{"vkGetPhysicalDeviceSurfacePresentModesKHR"},
+    .{"vkGetPhysicalDeviceQueueFamilyProperties2"},
+    .{"vkEnumerateInstanceLayerProperties"},
+    .{"vkEnumerateInstanceExtensionProperties"},
+    .{"vkEnumerateDeviceLayerProperties"},
     .{"vkEnumerateDeviceExtensionProperties"},
+    .{"vkGetImageSparseMemoryRequirements"},
+    .{"vkGetImageSparseMemoryRequirements2"},
+    .{"vkGetDeviceImageSparseMemoryRequirements"},
+    .{"vkGetPhysicalDeviceSparseImageFormatProperties"},
+    .{"vkGetPhysicalDeviceSparseImageFormatProperties2"},
+    .{"vkGetPhysicalDeviceToolProperties"},
+    .{"vkGetPipelineCacheData"},
+
+    .{"vkGetPhysicalDeviceSurfaceFormatsKHR"},
+    .{"vkGetPhysicalDeviceSurfaceFormats2KHR"},
+    .{"vkGetPhysicalDeviceSurfacePresentModesKHR"},
+
     .{"vkGetSwapchainImagesKHR"},
+    .{"vkGetPhysicalDevicePresentRectanglesKHR"},
+
+    .{"vkGetPhysicalDeviceCalibrateableTimeDomainsKHR"},
 });
 
 // Given one of the above commands, returns the type of the array elements


### PR DESCRIPTION
Closes #145

Could probably still use a little cleanup, but I think it's getting there. Some places could be improved using string interpolation instead of calling the `render*()` functions, but the problem is they have some handling of casing, prefix stripping, etc. that would need to be duplicated or refactored in order to get the formatted names as a string. Shouldn't be too bad but not sure whether it's worth cluttering up the existing code for this, let me know if you want me to try it that way.

TODO:
- ~fill in full list of functions~
- ~add proxy functions~
- ~update examples~

Output (mostly unchanged from the issue):
```zig
pub const EnumerateInstanceExtensionPropertiesAllocError =
    EnumerateInstanceExtensionPropertiesError || Allocator.Error;
pub fn enumerateInstanceExtensionPropertiesAlloc(
    self: Self,
    p_layer_name: ?[*:0]const u8,
    allocator: Allocator,
) EnumerateInstanceExtensionPropertiesAllocError![]ExtensionProperties {
    var count: u32 = undefined;
    var data: []ExtensionProperties = &.{};
    errdefer allocator.free(data);
    var result = Result.incomplete;
    while (result == .incomplete) {
        _ = try self.enumerateInstanceExtensionProperties(p_layer_name, &count, null);
        data = try allocator.realloc(data, count);
        result = try self.enumerateInstanceExtensionProperties(p_layer_name, &count, data.ptr);
    }
    return if (count == data.len) data else allocator.realloc(data, count);
}

pub fn getPhysicalDeviceQueueFamilyPropertiesAlloc(
    self: Self,
    physical_device: PhysicalDevice,
    allocator: Allocator,
) Allocator.Error![]QueueFamilyProperties {
    var count: u32 = undefined;
    self.getPhysicalDeviceQueueFamilyProperties(physical_device, &count, null);
    const data = try allocator.alloc(QueueFamilyProperties, count);
    errdefer allocator.free(data);
    self.getPhysicalDeviceQueueFamilyProperties(physical_device, &count, data.ptr);
    return if (count == data.len) data else allocator.realloc(data, count);
}
```