### PR TITLE
Add ability to pass a LazyPath as compile command to the ShaderCompileStep

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -35,7 +35,8 @@ pub fn build(b: *std.Build) void {
 
     const shaders = ShaderCompileStep.create(
         b,
-        &[_][]const u8{ "glslc", "--target-env=vulkan1.2" },
+        .{ .real_path = "glslc" },
+        &[_][]const u8{"--target-env=vulkan1.2"},
         "-o",
     );
     shaders.add("triangle_vert", "shaders/triangle.vert", .{});


### PR DESCRIPTION
This allows for passing paths to executables generated by the compiler as the compile command.