### PR TITLE
Change shader build integration to be compatible with zig 0.13.0

### DIFF
--- a/src/build_integration.zig
+++ b/src/build_integration.zig
@@ -165,8 +165,8 @@ pub const ShaderCompileStep = struct {
     }
 
     /// Internal build function.
-    fn make(step: *Build.Step, options: Build.Step.MakeOptions) !void {
-        _ = options;
+    fn make(step: *Build.Step, prog_node: std.Progress.Node) !void {
+        _ = prog_node;
         const b = step.owner;
         const self: *ShaderCompileStep = @fieldParentPtr("step", step);
         const cwd = std.fs.cwd();


### PR DESCRIPTION
Running shader compilation with zig version 0.13.0 was throwing the following error:
```
/src/build_integration.zig:168:51: error: root struct of file 'Build.Step' has no member named 'MakeOptions'
    fn make(step: *Build.Step, options: Build.Step.MakeOptions) !void {
                                        ~~~~~~~~~~^~~~~~~~~~~~
```

This small change fixes that, but makes the library incompatible with previous zig versions.