### PR TITLE
Increase eval branch quota

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1400,7 +1400,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\            break :blk cmds;
                 \\        }};
                 \\        pub const Dispatch = blk: {{
-                \\            @setEvalBranchQuota(100_000);
+                \\            @setEvalBranchQuota(1_000_000);
                 \\            const Type = std.builtin.Type;
                 \\            const fields_len = fields_len: {{
                 \\                var fields_len: u32 = 0;


### PR DESCRIPTION
The limit is being hit when enabling core APIs up to 1.3, reproducible with the triangle example:

```
diff --git a/examples/graphics_context.zig b/examples/graphics_context.zig
index f2d0fef..452de08 100644
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -18,6 +18,9 @@ const apis: []const vk.ApiInfo = &.{
     },
     // Or you can add entire feature sets or extensions
     vk.features.version_1_0,
+    vk.features.version_1_1,
+    vk.features.version_1_2,
+    vk.features.version_1_3,
     vk.extensions.khr_surface,
     vk.extensions.khr_swapchain,
 };
```

```
$ zig build
install
└─ install triangle
   └─ zig build-exe triangle Debug native 1 errors
/home/poconn/.local/bin/lib/std/meta.zig:553:12: error: evaluation exceeded 100000 backwards branches
    inline for (field_infos, 0..) |field, i| {
    ~~~~~~~^~~
/home/poconn/.local/bin/lib/std/meta.zig:553:12: note: use @setEvalBranchQuota() to raise the branch limit from 100000
.zig-cache/o/d2e9780c6536d8d352b813519c69b0fe/vk.zig:28370:76: note: called from here
                    const field_tag = std.enums.nameCast(std.meta.FieldEnum(DeviceCommandFlags), field.name);
                                                         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
referenced by:
    vk.DeviceWrapper(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..7]): .zig-cache/o/d2e9780c6536d8d352b813519c69b0fe/vk.zig:28346:19
    Wrapper: .zig-cache/o/d2e9780c6536d8d352b813519c69b0fe/vk.zig:28345:12
```
I see it was already recently increased and so it's surprising that it's necessary again, maybe recent compiler changes?
```
$ zig version
0.14.0-dev.1511+54b668f8a
```