### PR TITLE
Remove additional null termination

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1496,8 +1496,7 @@ fn Renderer(comptime WriterType: type) type {
                 \\pub fn load({[params]s}) Self {{
                 \\    var self: Self = .{{ .dispatch = .{{}} }};
                 \\    inline for (std.meta.fields(Dispatch)) |field| {{
-                \\        const name: [*:0]const u8 = @ptrCast(field.name ++ "\x00");
-                \\        const cmd_ptr = loader({[first_arg]s}, name) orelse undefined;
+                \\        const cmd_ptr = loader({[first_arg]s}, field.name.ptr) orelse undefined;
                 \\        @field(self.dispatch, field.name) = @ptrCast(cmd_ptr);
                 \\    }}
                 \\    return self;


### PR DESCRIPTION
[`std.builtin.Type.StructField.name`](https://ziglang.org/documentation/master/std/#std.builtin.Type.StructField) has type `[:0]const u8`.

LLVM-IR before this PR:

```llvm
@__anon_13958 = internal unnamed_addr constant [18 x i8] c"vkCreateInstance\00\00", align 1
@__anon_13974 = internal unnamed_addr constant [23 x i8] c"vkGetInstanceProcAddr\00\00", align 1
@__anon_13985 = internal unnamed_addr constant [28 x i8] c"vkEnumerateInstanceVersion\00\00", align 1
@__anon_13996 = internal unnamed_addr constant [36 x i8] c"vkEnumerateInstanceLayerProperties\00\00", align 1
@__anon_14010 = internal unnamed_addr constant [40 x i8] c"vkEnumerateInstanceExtensionProperties\00\00", align 1
```

After this PR:


```llvm
@__anon_13896 = internal unnamed_addr constant [17 x i8] c"vkCreateInstance\00", align 1
@__anon_13904 = internal unnamed_addr constant [22 x i8] c"vkGetInstanceProcAddr\00", align 1
@__anon_13912 = internal unnamed_addr constant [27 x i8] c"vkEnumerateInstanceVersion\00", align 1
@__anon_13920 = internal unnamed_addr constant [35 x i8] c"vkEnumerateInstanceLayerProperties\00", align 1
@__anon_13929 = internal unnamed_addr constant [39 x i8] c"vkEnumerateInstanceExtensionProperties\00", align 1
```