### PR TITLE
Fix crash of the example related to swapchain recreation during resizing.

### DIFF
--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -80,7 +80,11 @@ pub const Swapchain = struct {
         errdefer gc.dev.destroySemaphore(next_image_acquired, null);
 
         const result = try gc.dev.acquireNextImageKHR(handle, std.math.maxInt(u64), next_image_acquired, .null_handle);
-        if (result.result != .success) {
+        // event with a .suboptimal_khr we can still go on to present
+        // if we error even for .suboptimal_khr the example will crash and segfault
+        // on resize, since even the recreated swapchain can be suboptimal during a
+        // resize.
+        if (result.result == .not_ready or result.result == .timeout) {
             return error.ImageAcquireFailed;
         }
 


### PR DESCRIPTION
When resizing the window created by the example the `acquireNextImageKHR` call may return `.suboptimal_khr`. This will then crash the example with a segmentation fault since some resources are de-initialized twice, such as the swapchain handle and swapchain images.