### PR TITLE
Fixed crash under Wayland when using a scaling factor.

### DIFF
--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -137,7 +137,6 @@ pub fn main() !void {
 
         const cmdbuf = cmdbufs[swapchain.image_index];
 
-
         if (state == .suboptimal or extent.width != @as(u32, @intCast(w)) or extent.height != @as(u32, @intCast(h))) {
             extent.width = @intCast(w);
             extent.height = @intCast(h);

--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -123,6 +123,7 @@ pub fn main() !void {
     );
     defer destroyCommandBuffers(&gc, pool, allocator, cmdbufs);
 
+    var state: Swapchain.PresentState = .optimal;
     while (c.glfwWindowShouldClose(window) == c.GLFW_FALSE) {
         var w: c_int = undefined;
         var h: c_int = undefined;
@@ -136,10 +137,6 @@ pub fn main() !void {
 
         const cmdbuf = cmdbufs[swapchain.image_index];
 
-        const state = swapchain.present(cmdbuf) catch |err| switch (err) {
-            error.OutOfDateKHR => Swapchain.PresentState.suboptimal,
-            else => |narrow| return narrow,
-        };
 
         if (state == .suboptimal or extent.width != @as(u32, @intCast(w)) or extent.height != @as(u32, @intCast(h))) {
             extent.width = @intCast(w);
@@ -161,6 +158,10 @@ pub fn main() !void {
                 framebuffers,
             );
         }
+        state = swapchain.present(cmdbuf) catch |err| switch (err) {
+            error.OutOfDateKHR => Swapchain.PresentState.suboptimal,
+            else => |narrow| return narrow,
+        };
 
         c.glfwPollEvents();
     }


### PR DESCRIPTION
When running the example on a Wayland system using a scaling factor of 3, the example crashes since the size of the initial buffer created by GLFW is not divisible by the scaling factor. This violates the Wayland protocol, which results in a crash when trying to present to the `wl_surface`:
```
wl_surface#24: error 2: Buffer size (554x646) is not divisible by scale (3)
```

Allowing for a resize of the swapchain images before presenting fixes this issue.

I am admittedly not entirely sure why this fixes the issue, since when logging the resizes, there is at least one resize to a buffer size that is invalid, without causing a crash:
```
info: framebuffer size : swapchain extent before resize
info: 554, 646 : 800, 600
info: 1662, 1938 : 554, 646
```
But I assume that this is related to when GLFW calls `wl_surface::set_buffer_scale` to set the scale of the created surface and `wl_surface::commit` to apply this change. See the Wayland spec for [wl_surface](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_surface).