### PR TITLE
Turned Bool32 into an enum

### DIFF
--- a/src/vulkan/c_parse.zig
+++ b/src/vulkan/c_parse.zig
@@ -259,9 +259,25 @@ pub fn parseTypedef(allocator: Allocator, xctok: *XmlCTokenizer, ptrs_optional: 
     if (try xctok.peek()) |_| {
         return error.InvalidSyntax;
     }
+    const name = decl.name orelse return error.MissingTypeIdentifier;
 
+    if (mem.eql(u8, name, "VkBool32")) {
+        const fields = [_]registry.Enum.Field{
+            .{ .name = "false", .value = .{ .int = 0 } },
+            .{ .name = "true", .value = .{ .int = 1 } },
+        };
+        const enumeration = registry.Enum{
+            .fields = try allocator.dupe(registry.Enum.Field, &fields),
+            .bitwidth = 32,
+            .is_bitmask = false,
+        };
+        return registry.Declaration{
+            .name = name,
+            .decl_type = .{ .enumeration = enumeration },
+        };
+    }
     return registry.Declaration{
-        .name = decl.name orelse return error.MissingTypeIdentifier,
+        .name = name,
         .decl_type = .{ .typedef = decl.decl_type },
     };
 }

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1109,7 +1109,7 @@ const Renderer = struct {
             try self.writer.writeAll(" = .");
             try self.writeIdentifierWithCase(.snake, stype["VK_STRUCTURE_TYPE_".len..]);
         } else if (field.field_type == .name and mem.eql(u8, "VkBool32", field.field_type.name) and isFeatureStruct(name, container.extends)) {
-            try self.writer.writeAll(" = FALSE");
+            try self.writer.writeAll(" = .false");
         } else if (field.is_optional) {
             if (field.field_type == .name) {
                 const field_type_name = field.field_type.name;


### PR DESCRIPTION
You often need to assign `vk.TRUE` and `vk.FALSE` in Vulkan code, but in a Zig binding this looks out of place—more reminiscent of `@cImport()`. Most Vulkan enumerations are already mapped to Zig enums, including `null_handle`, while screaming-case constants are typically reserved for typeless constants or sentinel values. Since `true` and `false` clearly belong to a logical type, they should instead be defined within an enum.

I did not add the other edge cases to strip the declarations of `TRUE` and `FALSE`, but their existence doesn't hurt much either.

I benchmarked the edit using [poop](https://github.com/andrewrk/poop) to see if the string comparison placed inside a relatively hot path negatively affected performance, but in both Debug and ReleaseFast the wall time was only around +3% ± 2% slower.