### PR TITLE
Fixed incorrect parameter order for zig 0.15.1

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -102,12 +102,12 @@ pub fn main() !void {
     };
 
     const cwd = std.fs.cwd();
-    const xml_src = cwd.readFileAlloc(xml_path, allocator, .unlimited) catch |err| {
+    const xml_src = cwd.readFileAlloc(allocator, xml_path, std.math.maxInt(usize)) catch |err| {
         std.process.fatal("failed to open input file '{s}' ({s})", .{ xml_path, @errorName(err) });
     };
 
     const maybe_video_xml_src = if (maybe_video_xml_path) |video_xml_path|
-        cwd.readFileAlloc(video_xml_path, allocator, .unlimited) catch |err| {
+        cwd.readFileAlloc(allocator, video_xml_path, std.math.maxInt(usize)) catch |err| {
             std.process.fatal("failed to open input file '{s}' ({s})", .{ video_xml_path, @errorName(err) });
         }
     else


### PR DESCRIPTION
The allocator argument for `std.fs.Cwd.readFileAlloc` got switched around in the new zig version, and `.unlimited` was changed to `std.math.maxInt(usize)`.
This should make it compatible with 0.15.1.