### PR TITLE
Fix build on latest Zig stable.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -102,12 +102,12 @@ pub fn main() !void {
     };
 
     const cwd = std.fs.cwd();
-    const xml_src = cwd.readFileAlloc(xml_path, allocator, .unlimited) catch |err| {
+    const xml_src = cwd.readFileAlloc(allocator, xml_path, std.math.maxInt(usize)) catch |err| {
         std.process.fatal("failed to open input file '{s}' ({s})", .{ xml_path, @errorName(err) });
     };
 
     const maybe_video_xml_src = if (maybe_video_xml_path) |video_xml_path|
-        cwd.readFileAlloc(video_xml_path, allocator, .unlimited) catch |err| {
+        cwd.readFileAlloc(allocator, video_xml_path, std.math.maxInt(usize)) catch |err| {
             std.process.fatal("failed to open input file '{s}' ({s})", .{ video_xml_path, @errorName(err) });
         }
     else


### PR DESCRIPTION
This PR fixes the `cwd.readFileAlloc()` calls so that they compile by reordering the arguments so they are in the correct order, and replacing the nonexistant enum value `.unlimited` that was probably guessed with `std.math.maxInt(usize)` since that has a near equivalent effect anyways.