### PR TITLE
Fixed count type mismatch for enumeration functions that don't use u32

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -2042,7 +2042,7 @@ const Renderer = struct {
 
             return error.InvalidRegistry;
         };
-        
+
         try self.renderAllocWrapperPrototype(name, params, returns_vk_result, data_type, "", .wrapper);
 
         try self.writer.writeAll("{\n");


### PR DESCRIPTION
Allocation wrappers around enumerate functions were previously unconditionally generated with a u32 count variable. This doesn't work for functions like `vkGetPipelineCacheData` and `vkGetQueryPoolResults`, which take a `usize` and `void*` to a buffer.

From what I could find functions either use xxxCount with a typed pointer or xxxSize with a `void*` to a buffer. Since Zig doesn't seem to allocate memory when `[]void` is passed to `realloc`, I chose to make them return `[]u8` instead.