### PR TITLE
generate slice param instead of separate len and ptr params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 zig-cache/
-zig-out/
-.vscode/.zig-cache/
 .zig-cache/
-examples/.zig-cache
+zig-out/
+zig-pkg/

--- a/README.md
+++ b/README.md
@@ -171,31 +171,13 @@ Wrappers are generated according to the following rules:
   * If there are multiple return values selected, an additional struct is generated. The original call's return value is called `return_value`, `VkResult` is named `result`, and the out parameters are called the same except `p_` is removed. They are generated in this order.
 * Any const non-optional single-item pointer is interpreted as an in-parameter. For these, one level of indirection is removed so that create info structure pointers can now be passed as values, enabling the ability to use struct literals for these parameters.
 * Error codes are translated into Zig errors.
-* Buffer pointer parameters that have an associated length parameter are combined into a typed `Slice`. The length parameter is removed from the wrapper signature. See [Typed Slices](#typed-slices) for details.
+* Buffer pointer parameters that have an associated length parameter are combined into a `slice`. The length parameter is removed from the wrapper signature. See [slices](#slices) for details.
 
-#### Typed Slices
+#### slices
 
-When a Vulkan command takes a pointer and a separate count/length parameter, the wrapper combines them into a `Slice(PointerType, LenType)`. This preserves the exact type of the length parameter from the Vulkan specification (typically `u32`).
-
-```zig
-pub fn Slice(comptime PointerType: type, comptime LenType: type) type
-```
-
-When multiple slice parameters share the same length parameter, a debug assertion is generated to verify that their lengths match.
-
+When a Vulkan command takes a pointer and a separate count/length parameter, the wrapper combines them into a `slice`.
+When multiple `slice` parameters share the same length parameter, a debug assertion is generated to verify that their lengths match.
 This conversion only applies to commands where the length is a plain integer parameter. Enumeration-style commands are not affected.
-
-To construct a `Slice` from a standard Zig slice:
-```zig
-const buffers: []const vk.Buffer = &.{ buffer_a, buffer_b };
-const offsets: []const vk.DeviceSize = &.{ 0, 256 };
-vkd.cmdBindVertexBuffers(
-    cmd_buf,
-    0,
-    .fromSlice(buffers),
-    .fromSlice(offsets),
-);
-```
 
 #### Initializing Wrappers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Vulkan binding generator for Zig.
 
 ## Overview
 
-vulkan-zig attempts to provide a better experience to programming Vulkan applications in Zig, by providing features such as integration of vulkan errors with Zig's error system, function pointer loading, renaming fields to standard Zig style, better bitfield handling, turning out parameters into return values and more.
+vulkan-zig attempts to provide a better experience to programming Vulkan applications in Zig, by providing features such as integration of vulkan errors with Zig's error system, function pointer loading, renaming fields to standard Zig style, better bitfield handling, turning out parameters into return values, slices for buffer parameters and more.
 
 vulkan-zig is automatically tested daily against the latest vk.xml and zig, and supports vk.xml from version 1.x.163.
 
@@ -171,7 +171,31 @@ Wrappers are generated according to the following rules:
   * If there are multiple return values selected, an additional struct is generated. The original call's return value is called `return_value`, `VkResult` is named `result`, and the out parameters are called the same except `p_` is removed. They are generated in this order.
 * Any const non-optional single-item pointer is interpreted as an in-parameter. For these, one level of indirection is removed so that create info structure pointers can now be passed as values, enabling the ability to use struct literals for these parameters.
 * Error codes are translated into Zig errors.
-* As of yet, there is no specific handling of enumeration style commands or other commands which accept slices.
+* Buffer pointer parameters that have an associated length parameter are combined into a typed `Slice`. The length parameter is removed from the wrapper signature. See [Typed Slices](#typed-slices) for details.
+
+#### Typed Slices
+
+When a Vulkan command takes a pointer and a separate count/length parameter, the wrapper combines them into a `Slice(PointerType, LenType)`. This preserves the exact type of the length parameter from the Vulkan specification (typically `u32`).
+
+```zig
+pub fn Slice(comptime PointerType: type, comptime LenType: type) type
+```
+
+When multiple slice parameters share the same length parameter, a debug assertion is generated to verify that their lengths match.
+
+This conversion only applies to commands where the length is a plain integer parameter. Enumeration-style commands are not affected.
+
+To construct a `Slice` from a standard Zig slice:
+```zig
+const buffers: []const vk.Buffer = &.{ buffer_a, buffer_b };
+const offsets: []const vk.DeviceSize = &.{ 0, 256 };
+vkd.cmdBindVertexBuffers(
+    cmd_buf,
+    0,
+    .fromSlice(buffers),
+    .fromSlice(offsets),
+);
+```
 
 #### Initializing Wrappers
 

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -175,11 +175,11 @@ pub const Swapchain = struct {
         // Step 1: Make sure the current frame has finished rendering
         const current = self.currentSwapImage();
         try current.waitForFence(self.gc);
-        try self.gc.dev.resetFences(.fromSlice(&.{current.frame_fence}));
+        try self.gc.dev.resetFences(&.{current.frame_fence});
 
         // Step 2: Submit the command buffer
         const wait_stage = [_]vk.PipelineStageFlags{.{ .top_of_pipe_bit = true }};
-        try self.gc.dev.queueSubmit(self.gc.graphics_queue.handle, .fromSlice(&.{.{
+        try self.gc.dev.queueSubmit(self.gc.graphics_queue.handle, &.{.{
             .wait_semaphore_count = 1,
             .p_wait_semaphores = @ptrCast(&current.image_acquired),
             .p_wait_dst_stage_mask = &wait_stage,
@@ -187,7 +187,7 @@ pub const Swapchain = struct {
             .p_command_buffers = @ptrCast(&cmdbuf),
             .signal_semaphore_count = 1,
             .p_signal_semaphores = @ptrCast(&current.render_finished),
-        }}), current.frame_fence);
+        }}, current.frame_fence);
 
         // Step 3: Present the current frame
         _ = try self.gc.dev.queuePresentKHR(self.gc.present_queue.handle, &.{
@@ -267,7 +267,7 @@ const SwapImage = struct {
     }
 
     fn waitForFence(self: SwapImage, gc: *const GraphicsContext) !void {
-        _ = try gc.dev.waitForFences(.fromSlice(&.{self.frame_fence}), .true, std.math.maxInt(u64));
+        _ = try gc.dev.waitForFences(&.{self.frame_fence}, .true, std.math.maxInt(u64));
     }
 };
 

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -175,11 +175,11 @@ pub const Swapchain = struct {
         // Step 1: Make sure the current frame has finished rendering
         const current = self.currentSwapImage();
         try current.waitForFence(self.gc);
-        try self.gc.dev.resetFences(1, @ptrCast(&current.frame_fence));
+        try self.gc.dev.resetFences(.fromSlice(&.{current.frame_fence}));
 
         // Step 2: Submit the command buffer
         const wait_stage = [_]vk.PipelineStageFlags{.{ .top_of_pipe_bit = true }};
-        try self.gc.dev.queueSubmit(self.gc.graphics_queue.handle, 1, &[_]vk.SubmitInfo{.{
+        try self.gc.dev.queueSubmit(self.gc.graphics_queue.handle, .fromSlice(&.{.{
             .wait_semaphore_count = 1,
             .p_wait_semaphores = @ptrCast(&current.image_acquired),
             .p_wait_dst_stage_mask = &wait_stage,
@@ -187,7 +187,7 @@ pub const Swapchain = struct {
             .p_command_buffers = @ptrCast(&cmdbuf),
             .signal_semaphore_count = 1,
             .p_signal_semaphores = @ptrCast(&current.render_finished),
-        }}, current.frame_fence);
+        }}), current.frame_fence);
 
         // Step 3: Present the current frame
         _ = try self.gc.dev.queuePresentKHR(self.gc.present_queue.handle, &.{
@@ -267,7 +267,7 @@ const SwapImage = struct {
     }
 
     fn waitForFence(self: SwapImage, gc: *const GraphicsContext) !void {
-        _ = try gc.dev.waitForFences(1, @ptrCast(&self.frame_fence), .true, std.math.maxInt(u64));
+        _ = try gc.dev.waitForFences(.fromSlice(&.{self.frame_fence}), .true, std.math.maxInt(u64));
     }
 };
 

--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -217,7 +217,7 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
         .level = .primary,
         .command_buffer_count = 1,
     }, @ptrCast(&cmdbuf_handle));
-    defer gc.dev.freeCommandBuffers(pool, .fromSlice(&.{cmdbuf_handle}));
+    defer gc.dev.freeCommandBuffers(pool, &.{cmdbuf_handle});
 
     const cmdbuf = GraphicsContext.CommandBuffer.init(cmdbuf_handle, gc.dev.wrapper);
 
@@ -230,7 +230,7 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
         .dst_offset = 0,
         .size = size,
     };
-    cmdbuf.copyBuffer(src, dst, .fromSlice(&.{region}));
+    cmdbuf.copyBuffer(src, dst, &.{region});
 
     try cmdbuf.endCommandBuffer();
 
@@ -239,7 +239,7 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
         .p_command_buffers = &.{cmdbuf.handle},
         .p_wait_dst_stage_mask = undefined,
     };
-    try gc.dev.queueSubmit(gc.graphics_queue.handle, .fromSlice(&.{si}), .null_handle);
+    try gc.dev.queueSubmit(gc.graphics_queue.handle, &.{si}, .null_handle);
     try gc.dev.queueWaitIdle(gc.graphics_queue.handle);
 }
 
@@ -261,7 +261,7 @@ fn createCommandBuffers(
         .level = .primary,
         .command_buffer_count = @intCast(cmdbufs.len),
     }, cmdbufs.ptr);
-    errdefer gc.dev.freeCommandBuffers(pool, .fromSlice(cmdbufs));
+    errdefer gc.dev.freeCommandBuffers(pool, cmdbufs);
 
     const clear = vk.ClearValue{
         .color = .{ .float_32 = .{ 0, 0, 0, 1 } },
@@ -284,8 +284,8 @@ fn createCommandBuffers(
     for (cmdbufs, framebuffers) |cmdbuf, framebuffer| {
         try gc.dev.beginCommandBuffer(cmdbuf, &.{});
 
-        gc.dev.cmdSetViewport(cmdbuf, 0, .fromSlice(&.{viewport}));
-        gc.dev.cmdSetScissor(cmdbuf, 0, .fromSlice(&.{scissor}));
+        gc.dev.cmdSetViewport(cmdbuf, 0, &.{viewport});
+        gc.dev.cmdSetScissor(cmdbuf, 0, &.{scissor});
 
         // This needs to be a separate definition - see https://github.com/ziglang/zig/issues/7627.
         const render_area = vk.Rect2D{
@@ -303,18 +303,17 @@ fn createCommandBuffers(
 
         gc.dev.cmdBindPipeline(cmdbuf, .graphics, pipeline);
         const offset = [_]vk.DeviceSize{0};
-        gc.dev.cmdBindVertexBuffers(cmdbuf, 0, .fromSlice(&.{buffer}), .fromSlice(&offset));
+        gc.dev.cmdBindVertexBuffers(cmdbuf, 0, &.{buffer}, &offset);
         gc.dev.cmdDraw(cmdbuf, vertices.len, 1, 0, 0);
 
         gc.dev.cmdEndRenderPass(cmdbuf);
         try gc.dev.endCommandBuffer(cmdbuf);
     }
-
     return cmdbufs;
 }
 
 fn destroyCommandBuffers(gc: *const GraphicsContext, pool: vk.CommandPool, allocator: Allocator, cmdbufs: []vk.CommandBuffer) void {
-    gc.dev.freeCommandBuffers(pool, .fromSlice(cmdbufs));
+    gc.dev.freeCommandBuffers(pool, cmdbufs);
     allocator.free(cmdbufs);
 }
 
@@ -495,9 +494,9 @@ fn createPipeline(
     var pipeline: vk.Pipeline = undefined;
     _ = try gc.dev.createGraphicsPipelines(
         .null_handle,
-        .fromSlice(&.{gpci}),
+        &.{gpci},
         null,
-        .fromSlice((&pipeline)[0..1]),
+        (&pipeline)[0..1],
     );
     return pipeline;
 }

--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -217,7 +217,7 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
         .level = .primary,
         .command_buffer_count = 1,
     }, @ptrCast(&cmdbuf_handle));
-    defer gc.dev.freeCommandBuffers(pool, 1, @ptrCast(&cmdbuf_handle));
+    defer gc.dev.freeCommandBuffers(pool, .fromSlice(&.{cmdbuf_handle}));
 
     const cmdbuf = GraphicsContext.CommandBuffer.init(cmdbuf_handle, gc.dev.wrapper);
 
@@ -230,16 +230,16 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
         .dst_offset = 0,
         .size = size,
     };
-    cmdbuf.copyBuffer(src, dst, 1, @ptrCast(&region));
+    cmdbuf.copyBuffer(src, dst, .fromSlice(&.{region}));
 
     try cmdbuf.endCommandBuffer();
 
     const si = vk.SubmitInfo{
         .command_buffer_count = 1,
-        .p_command_buffers = (&cmdbuf.handle)[0..1],
+        .p_command_buffers = &.{cmdbuf.handle},
         .p_wait_dst_stage_mask = undefined,
     };
-    try gc.dev.queueSubmit(gc.graphics_queue.handle, 1, @ptrCast(&si), .null_handle);
+    try gc.dev.queueSubmit(gc.graphics_queue.handle, .fromSlice(&.{si}), .null_handle);
     try gc.dev.queueWaitIdle(gc.graphics_queue.handle);
 }
 
@@ -261,7 +261,7 @@ fn createCommandBuffers(
         .level = .primary,
         .command_buffer_count = @intCast(cmdbufs.len),
     }, cmdbufs.ptr);
-    errdefer gc.dev.freeCommandBuffers(pool, @intCast(cmdbufs.len), cmdbufs.ptr);
+    errdefer gc.dev.freeCommandBuffers(pool, .fromSlice(cmdbufs));
 
     const clear = vk.ClearValue{
         .color = .{ .float_32 = .{ 0, 0, 0, 1 } },
@@ -284,8 +284,8 @@ fn createCommandBuffers(
     for (cmdbufs, framebuffers) |cmdbuf, framebuffer| {
         try gc.dev.beginCommandBuffer(cmdbuf, &.{});
 
-        gc.dev.cmdSetViewport(cmdbuf, 0, 1, @ptrCast(&viewport));
-        gc.dev.cmdSetScissor(cmdbuf, 0, 1, @ptrCast(&scissor));
+        gc.dev.cmdSetViewport(cmdbuf, 0, .fromSlice(&.{viewport}));
+        gc.dev.cmdSetScissor(cmdbuf, 0, .fromSlice(&.{scissor}));
 
         // This needs to be a separate definition - see https://github.com/ziglang/zig/issues/7627.
         const render_area = vk.Rect2D{
@@ -303,7 +303,7 @@ fn createCommandBuffers(
 
         gc.dev.cmdBindPipeline(cmdbuf, .graphics, pipeline);
         const offset = [_]vk.DeviceSize{0};
-        gc.dev.cmdBindVertexBuffers(cmdbuf, 0, 1, @ptrCast(&buffer), &offset);
+        gc.dev.cmdBindVertexBuffers(cmdbuf, 0, .fromSlice(&.{buffer}), .fromSlice(&offset));
         gc.dev.cmdDraw(cmdbuf, vertices.len, 1, 0, 0);
 
         gc.dev.cmdEndRenderPass(cmdbuf);
@@ -314,7 +314,7 @@ fn createCommandBuffers(
 }
 
 fn destroyCommandBuffers(gc: *const GraphicsContext, pool: vk.CommandPool, allocator: Allocator, cmdbufs: []vk.CommandBuffer) void {
-    gc.dev.freeCommandBuffers(pool, @truncate(cmdbufs.len), cmdbufs.ptr);
+    gc.dev.freeCommandBuffers(pool, .fromSlice(cmdbufs));
     allocator.free(cmdbufs);
 }
 
@@ -495,10 +495,9 @@ fn createPipeline(
     var pipeline: vk.Pipeline = undefined;
     _ = try gc.dev.createGraphicsPipelines(
         .null_handle,
-        1,
-        @ptrCast(&gpci),
+        .fromSlice(&.{gpci}),
         null,
-        @ptrCast(&pipeline),
+        .fromSlice((&pipeline)[0..1]),
     );
     return pipeline;
 }

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -2028,6 +2028,7 @@ const Renderer = struct {
         try self.writer.writeAll("(self: Self, ");
         for (params) |param| {
             const class = try self.classifyParam(params, param);
+            // Skip the dispatch type for proxying wrappers
             if (kind == .proxy and class == .dispatch_handle and mem.eql(u8, param.param_type.name, dispatch_handle)) {
                 continue;
             }
@@ -2206,13 +2207,12 @@ const Renderer = struct {
         }
     }
 
-    const FindRefSliceParamResult = struct { idx: usize, param: reg.Command.Param };
-    fn findRefSliceParam(self: Self, params: []const reg.Command.Param, len_name: []const u8) !?FindRefSliceParamResult {
-        var result: ?FindRefSliceParamResult = null;
-        for (params, 0..) |param, i| {
+    fn findRefSliceParam(self: Self, params: []const reg.Command.Param, len_name: []const u8) !?reg.Command.Param {
+        var result: ?reg.Command.Param = null;
+        for (params) |param| {
             if ((try self.classifyParam(params, param)) != .slice) continue;
             if (!mem.eql(u8, param.param_type.pointer.size.other_field, len_name)) continue;
-            result = .{ .idx = i, .param = param };
+            result = param;
             if (!param.param_type.pointer.is_optional) break;
         }
         return result;
@@ -2251,10 +2251,10 @@ const Renderer = struct {
     }
 
     fn renderSliceLenCallArg(self: *Self, len_param: reg.Command.Param, params: []const reg.Command.Param) !bool {
-        const ref = (try self.findRefSliceParam(params, len_param.name)) orelse return false;
+        const ref_param = (try self.findRefSliceParam(params, len_param.name)) orelse return false;
 
         try self.writer.writeAll("@intCast(");
-        if (ref.param.param_type.pointer.is_optional) {
+        if (ref_param.param_type.pointer.is_optional) {
             for (params) |param| {
                 if ((try self.classifyParam(params, param)) != .slice) continue;
                 if (!mem.eql(u8, param.param_type.pointer.size.other_field, len_param.name)) continue;
@@ -2264,7 +2264,7 @@ const Renderer = struct {
             }
             try self.writer.writeAll("0)");
         } else {
-            try self.renderParamName(ref.param.name);
+            try self.renderParamName(ref_param.name);
             try self.writer.writeAll(".len)");
         }
         return true;
@@ -2276,8 +2276,7 @@ const Renderer = struct {
         for (params) |len_param| {
             if ((try self.classifyParam(params, len_param)) != .buffer_len) continue;
 
-            const ref_result = (try self.findRefSliceParam(params, len_param.name)) orelse continue;
-            const ref_slice = ref_result.param;
+            const ref_slice = (try self.findRefSliceParam(params, len_param.name)) orelse continue;
             const ref_slice_opt = ref_slice.param_type.pointer.is_optional;
             const len_param_kept = !try self.shouldSkipLen(function_name, params, len_param);
 
@@ -2291,21 +2290,10 @@ const Renderer = struct {
 
             for (params) |other| {
                 const other_class = try self.classifyParam(params, other);
-                switch (other_class) {
-                    .slice => {
-                        if (!mem.eql(u8, other.param_type.pointer.size.other_field, len_param.name)) continue;
-                        if (ref_is_slice and mem.eql(u8, other.name, ref_param.name)) continue;
-                    },
-                    .buffer_len => {
-                        if (!mem.eql(u8, other.name, len_param.name)) continue;
-                        if (!ref_is_slice) continue;
-                        if (try self.shouldSkipLen(function_name, params, other)) continue;
-                    },
-                    else => continue,
-                }
-
-                const other_is_slice = other_class == .slice;
-                const other_opt = if (other_is_slice) other.param_type.pointer.is_optional else false;
+                if (other_class != .slice) continue;
+                if (!mem.eql(u8, other.param_type.pointer.size.other_field, len_param.name)) continue;
+                if (ref_is_slice and mem.eql(u8, other.name, ref_param.name)) continue;
+                const other_opt = other.param_type.pointer.is_optional;
 
                 try self.writer.writeAll("std.debug.assert(");
                 if (ref_is_opt) {
@@ -2326,10 +2314,8 @@ const Renderer = struct {
                 try self.writer.writeAll(" == ");
 
                 try self.renderParamName(other.name);
-                if (other_is_slice) {
-                    if (other_opt) try self.writer.writeAll(".?");
-                    try self.writer.writeAll(".len");
-                }
+                if (other_opt) try self.writer.writeAll(".?");
+                try self.writer.writeAll(".len");
 
                 try self.writer.writeAll(");\n");
             }

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -96,44 +96,6 @@ const preamble =
     \\    name: [:0]const u8 = "custom",
     \\    version: Version = makeApiVersion(0, 0, 0, 0),
     \\};
-    \\pub fn Slice(comptime Ptr: type, comptime LenT: type) type {
-    \\    const info = @typeInfo(Ptr);
-    \\    const ptr_info = switch (info) {
-    \\        .pointer => info.pointer,
-    \\        .optional => @typeInfo(info.optional.child).pointer,
-    \\        else => @compileError("expected pointer or optional pointer"),
-    \\    };
-    \\    const is_opt = switch (info) {
-    \\        .optional => true,
-    \\        else => false,
-    \\    };
-    \\    const NonOptSlice = if (ptr_info.is_const) []const ptr_info.child else []ptr_info.child;
-    \\    return struct {
-    \\        ptr: Ptr,
-    \\        len: LenT,
-    \\
-    \\        pub const @"null" = if (is_opt) @This(){ .len = 0, .ptr = null } else {};
-    \\        pub const SliceT = if (is_opt) ?NonOptSlice else NonOptSlice;
-    \\
-    \\        pub fn fromSlice(slice: SliceT) @This() {
-    \\            if (is_opt) {
-    \\                if (slice) |s| {
-    \\                    return .{ .ptr = s.ptr, .len = @intCast(s.len) };
-    \\                }
-    \\                return .{ .ptr = null, .len = 0 };
-    \\            }
-    \\            return .{ .ptr = slice.ptr, .len = @intCast(slice.len) };
-    \\        }
-    \\
-    \\        pub fn toSlice(self: @This()) SliceT {
-    \\            if (is_opt) {
-    \\                const p = self.ptr orelse return null;
-    \\                return p[0..@intCast(self.len)];
-    \\            }
-    \\            return self.ptr[0..@intCast(self.len)];
-    \\        }
-    \\    };
-    \\}
 ;
 
 // Keep in sync with above definition of FlagsMixin
@@ -1691,28 +1653,7 @@ const Renderer = struct {
         );
         try self.writeIdentifierWithCase(.camel, trimVkNamespace(name));
         try self.writer.writeByte('(');
-
-        for (command.params) |param| {
-            switch (try self.classifyParam(command.params, param)) {
-                .out_pointer => continue,
-                .buffer_len => {
-                    if ((try self.findSliceParamForLen(command.params, param.name)) != null) {
-                        continue;
-                    }
-                    try self.renderParamName(param.name);
-                },
-                .dispatch_handle => {
-                    if (mem.eql(u8, param.param_type.name, dispatch_handle)) {
-                        try self.writer.writeAll("self.handle");
-                    } else {
-                        try self.renderParamName(param.name);
-                    }
-                },
-                else => try self.renderParamName(param.name),
-            }
-            try self.writer.writeAll(", ");
-        }
-
+        try self.renderProxyCallArgs(name, command.params, command.params, dispatch_handle);
         try self.writer.writeAll(
             \\);
             \\}
@@ -1754,12 +1695,26 @@ const Renderer = struct {
         );
         try self.writeIdentifierWithCase(.camel, trimVkNamespace(name));
         try self.writer.writeByte('(');
+        try self.renderProxyCallArgs(wrapped_name, params, command.params, dispatch_handle);
+        try self.writer.writeAll(
+            \\allocator,);
+            \\}
+            \\
+        );
+    }
 
-        for (params) |param| {
-            switch (try self.classifyParam(params, param)) {
-                .out_pointer => return error.InvalidRegistry,
+    fn renderProxyCallArgs(
+        self: *Self,
+        name: []const u8,
+        iter_params: []const reg.Command.Param,
+        params: []const reg.Command.Param,
+        dispatch_handle: []const u8,
+    ) !void {
+        for (iter_params) |param| {
+            switch (try self.classifyParam(iter_params, param)) {
+                .out_pointer => continue,
                 .buffer_len => {
-                    if ((try self.findSliceParamForLen(params, param.name)) != null) {
+                    if (try self.shouldSkipLen(name, params, param)) {
                         continue;
                     }
                     try self.renderParamName(param.name);
@@ -1775,12 +1730,6 @@ const Renderer = struct {
             }
             try self.writer.writeAll(", ");
         }
-
-        try self.writer.writeAll(
-            \\allocator,);
-            \\}
-            \\
-        );
     }
 
     fn derefName(name: []const u8) []const u8 {
@@ -1847,11 +1796,11 @@ const Renderer = struct {
             if (class == .out_pointer) {
                 continue;
             }
-            if (try self.shouldSkipLen(command.params, param)) {
+            if (try self.shouldSkipLen(name, command.params, param)) {
                 continue;
             }
             if (class == .slice) {
-                try self.renderSliceParam(command.params, param);
+                try self.renderSliceParam(param);
             } else {
                 try self.renderWrapperParam(param);
             }
@@ -1896,14 +1845,14 @@ const Renderer = struct {
                     }
                 },
                 .buffer_len => {
-                    if (try self.findSliceParamForLen(command.params, param.name)) |slice_param| {
-                        try self.renderSliceLenCallArg(command.params, slice_param);
-                    } else {
+                    if (!try self.shouldSkipLen(name, command.params, param) or
+                        !try self.renderSliceLenCallArg(param, command.params))
+                    {
                         try self.renderParamName(param.name);
                     }
                 },
                 .slice => {
-                    try self.renderSlicePtrCallArg(command.params, param);
+                    try self.renderSlicePtrCallArg(param);
                 },
                 else => {
                     try self.renderParamName(param.name);
@@ -1934,7 +1883,6 @@ const Renderer = struct {
             if (command.return_type.* != .name or !mem.eql(u8, command.return_type.name, "VkResult")) {
                 return error.InvalidRegistry;
             }
-
             try returns.append(allocator, .{
                 .name = "result",
                 .return_value_type = command.return_type.*,
@@ -2076,18 +2024,18 @@ const Renderer = struct {
         kind: WrapperKind,
     ) !void {
         try self.writer.writeAll("pub fn ");
-        try self.renderWrapperName(name, "", .wrapper);
+        try self.renderWrapperName(name, dispatch_handle, kind);
         try self.writer.writeAll("(self: Self, ");
         for (params) |param| {
             const class = try self.classifyParam(params, param);
             if (kind == .proxy and class == .dispatch_handle and mem.eql(u8, param.param_type.name, dispatch_handle)) {
                 continue;
             }
-            if (try self.shouldSkipLen(params, param)) {
+            if (try self.shouldSkipLen(name, params, param)) {
                 continue;
             }
             if (class == .slice) {
-                try self.renderSliceParam(params, param);
+                try self.renderSliceParam(param);
             } else {
                 try self.renderWrapperParam(param);
             }
@@ -2196,14 +2144,14 @@ const Renderer = struct {
         for (params) |param| {
             switch (try self.classifyParam(params, param)) {
                 .buffer_len => {
-                    if (try self.findSliceParamForLen(params, param.name)) |slice_param| {
-                        try self.renderSliceLenCallArg(params, slice_param);
-                    } else {
+                    if (!try self.shouldSkipLen(wrapped_name, params, param) or
+                        !try self.renderSliceLenCallArg(param, params))
+                    {
                         try self.renderParamName(param.name);
                     }
                 },
                 .slice => {
-                    try self.renderSlicePtrCallArg(params, param);
+                    try self.renderSlicePtrCallArg(param);
                 },
                 else => {
                     try self.renderParamName(param.name);
@@ -2258,55 +2206,41 @@ const Renderer = struct {
         }
     }
 
-    fn findSliceParamForLen(self: Self, params: []const reg.Command.Param, len_name: []const u8) !?reg.Command.Param {
-        for (params) |param| {
-            if ((try self.classifyParam(params, param)) == .slice) {
-                if (mem.eql(u8, param.param_type.pointer.size.other_field, len_name)) {
-                    return param;
-                }
-            }
+    const FindRefSliceParamResult = struct { idx: usize, param: reg.Command.Param };
+    fn findRefSliceParam(self: Self, params: []const reg.Command.Param, len_name: []const u8) !?FindRefSliceParamResult {
+        var result: ?FindRefSliceParamResult = null;
+        for (params, 0..) |param, i| {
+            if ((try self.classifyParam(params, param)) != .slice) continue;
+            if (!mem.eql(u8, param.param_type.pointer.size.other_field, len_name)) continue;
+            result = .{ .idx = i, .param = param };
+            if (!param.param_type.pointer.is_optional) break;
         }
-        return null;
+        return result;
     }
 
-    fn shouldSkipLen(self: Self, params: []const reg.Command.Param, param: reg.Command.Param) !bool {
+    fn shouldSkipLen(self: Self, function_name: []const u8, params: []const reg.Command.Param, param: reg.Command.Param) !bool {
         if ((try self.classifyParam(params, param)) != .buffer_len) return false;
-        return (try self.findSliceParamForLen(params, param.name)) != null;
+        if ((try self.findRefSliceParam(params, param.name)) == null) return false;
+        const skip_set = std.StaticStringMap(void).initComptime(.{
+            .{ "vkCmdBeginTransformFeedbackEXT", {} },
+            .{ "vkCmdEndTransformFeedbackEXT", {} },
+        });
+        return !skip_set.has(function_name);
     }
 
-    fn isPlainSlice(self: Self, params: []const reg.Command.Param, param: reg.Command.Param) !bool {
-        if ((try self.classifyParam(params, param)) != .slice) return false;
-        const len_param = for (params) |p| {
-            if (mem.eql(u8, p.name, param.param_type.pointer.size.other_field)) break p;
-        } else return false;
-        if (len_param.param_type != .name) return false;
-        const zig_name = builtin_types.get(len_param.param_type.name) orelse return false;
-        return mem.eql(u8, zig_name, @typeName(usize));
-    }
-
-    fn renderSliceParam(self: *Self, params: []const reg.Command.Param, param: reg.Command.Param) !void {
+    fn renderSliceParam(self: *Self, param: reg.Command.Param) !void {
         const ptr = param.param_type.pointer;
-        const len_param = for (params) |p| {
-            if (mem.eql(u8, p.name, ptr.size.other_field)) break p;
-        } else return error.InvalidRegistry;
-
         try self.renderParamName(param.name);
-        try self.writer.writeAll(": Slice(");
-        if (ptr.is_optional) {
-            try self.writer.writeByte('?');
-        }
-        try self.writer.writeAll("[*]");
-        if (ptr.is_const) {
-            try self.writer.writeAll("const ");
-        }
+        try self.writer.writeByte(':');
+        if (ptr.is_optional) try self.writer.writeByte('?');
+        try self.writer.writeAll("[]");
+        if (ptr.is_const) try self.writer.writeAll("const ");
         try self.renderTypeInfo(ptr.child.*);
-        try self.writer.writeAll(", ");
-        try self.renderTypeInfo(len_param.param_type);
-        try self.writer.writeAll("), ");
+        try self.writer.writeByte(',');
     }
 
-    fn renderSlicePtrCallArg(self: *Self, params: []const reg.Command.Param, param: reg.Command.Param) !void {
-        if (param.param_type.pointer.is_optional and try self.isPlainSlice(params, param)) {
+    fn renderSlicePtrCallArg(self: *Self, param: reg.Command.Param) !void {
+        if (param.param_type.pointer.is_optional) {
             try self.writer.writeAll("if (");
             try self.renderParamName(param.name);
             try self.writer.writeAll(") |s| s.ptr else null");
@@ -2316,38 +2250,54 @@ const Renderer = struct {
         }
     }
 
-    fn renderSliceLenCallArg(self: *Self, params: []const reg.Command.Param, slice_param: reg.Command.Param) !void {
-        if (slice_param.param_type.pointer.is_optional and try self.isPlainSlice(params, slice_param)) {
-            try self.writer.writeAll("if (");
-            try self.renderParamName(slice_param.name);
-            try self.writer.writeAll(") |s| s.len else 0");
+    fn renderSliceLenCallArg(self: *Self, len_param: reg.Command.Param, params: []const reg.Command.Param) !bool {
+        const ref = (try self.findRefSliceParam(params, len_param.name)) orelse return false;
+
+        try self.writer.writeAll("@intCast(");
+        if (ref.param.param_type.pointer.is_optional) {
+            for (params) |param| {
+                if ((try self.classifyParam(params, param)) != .slice) continue;
+                if (!mem.eql(u8, param.param_type.pointer.size.other_field, len_param.name)) continue;
+                try self.writer.writeAll("if (");
+                try self.renderParamName(param.name);
+                try self.writer.writeAll(") |s| s.len else ");
+            }
+            try self.writer.writeAll("0)");
         } else {
-            try self.renderParamName(slice_param.name);
-            try self.writer.writeAll(".len");
+            try self.renderParamName(ref.param.name);
+            try self.writer.writeAll(".len)");
         }
+        return true;
     }
 
     fn renderSliceLenAsserts(self: *Self, params: []const reg.Command.Param) !void {
-        for (params) |param| {
-            if ((try self.classifyParam(params, param)) != .buffer_len) continue;
-            if ((try self.findSliceParamForLen(params, param.name)) == null) continue;
+        for (params) |len_param| {
+            if ((try self.classifyParam(params, len_param)) != .buffer_len) continue;
+            const ref = (try self.findRefSliceParam(params, len_param.name)) orelse continue;
 
-            var first: ?reg.Command.Param = null;
-            for (params) |p| {
-                if ((try self.classifyParam(params, p)) != .slice) continue;
-                if (!mem.eql(u8, p.param_type.pointer.size.other_field, param.name)) continue;
-                // Can't access .len directly on ?[]const T
-                if (p.param_type.pointer.is_optional and try self.isPlainSlice(params, p)) continue;
+            for (params, 0..) |other, i| {
+                if (i == ref.idx) continue;
+                if ((try self.classifyParam(params, other)) != .slice) continue;
+                if (!mem.eql(u8, other.param_type.pointer.size.other_field, len_param.name)) continue;
 
-                if (first) |f| {
-                    try self.writer.writeAll("std.debug.assert(");
-                    try self.renderParamName(f.name);
-                    try self.writer.writeAll(".len == ");
-                    try self.renderParamName(p.name);
-                    try self.writer.writeAll(".len);\n");
-                } else {
-                    first = p;
+                const ref_opt = ref.param.param_type.pointer.is_optional;
+                const other_opt = other.param_type.pointer.is_optional;
+
+                try self.writer.writeAll("std.debug.assert(");
+                if (ref_opt) {
+                    try self.renderParamName(ref.param.name);
+                    try self.writer.writeAll(" == null or ");
                 }
+                if (other_opt) {
+                    try self.renderParamName(other.name);
+                    try self.writer.writeAll(" == null or ");
+                }
+                try self.renderParamName(ref.param.name);
+                if (ref_opt) try self.writer.writeAll(".?");
+                try self.writer.writeAll(".len == ");
+                try self.renderParamName(other.name);
+                if (other_opt) try self.writer.writeAll(".?");
+                try self.writer.writeAll(".len);\n");
             }
         }
     }

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -112,6 +112,7 @@ const preamble =
     \\        ptr: Ptr,
     \\        len: LenT,
     \\
+    \\        pub const @"null" = if (is_opt) @This(){ .len = 0, .ptr = null } else {};
     \\        pub const SliceT = if (is_opt) ?NonOptSlice else NonOptSlice;
     \\
     \\        pub fn fromSlice(slice: SliceT) @This() {

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -2000,7 +2000,8 @@ const Renderer = struct {
         try self.renderWrapperPrototype(name, command, returns, "", .wrapper);
 
         if (returns.len == 1 and returns[0].origin == .inner_return_value) {
-            try self.writer.writeAll("{\n\n");
+            try self.writer.writeAll("{\n");
+            try self.renderSliceLenAsserts(command.params);
 
             if (returns_vk_result) {
                 try self.writer.writeAll("const result = ");
@@ -2015,7 +2016,7 @@ const Renderer = struct {
                 try self.writer.writeAll(";\n");
             }
 
-            try self.writer.writeAll("\n}\n");
+            try self.writer.writeAll("}\n");
             return;
         }
 
@@ -2025,6 +2026,8 @@ const Renderer = struct {
             "return_values";
 
         try self.writer.writeAll("{\n");
+        try self.renderSliceLenAsserts(command.params);
+
         if (returns.len == 1) {
             try self.writer.writeAll("var ");
             try self.writeIdentifierWithCase(.snake, return_var_name);
@@ -2139,6 +2142,7 @@ const Renderer = struct {
         try self.renderAllocWrapperPrototype(name, params, returns_vk_result, data_type, "", .wrapper);
 
         try self.writer.writeAll("{\n");
+        try self.renderSliceLenAsserts(params);
         try self.writer.writeAll("    var count: ");
         try self.renderTypeInfo(count_type);
         try self.writer.writeAll(" = undefined;\n");
@@ -2320,6 +2324,31 @@ const Renderer = struct {
         } else {
             try self.renderParamName(slice_param.name);
             try self.writer.writeAll(".len");
+        }
+    }
+
+    fn renderSliceLenAsserts(self: *Self, params: []const reg.Command.Param) !void {
+        for (params) |param| {
+            if ((try self.classifyParam(params, param)) != .buffer_len) continue;
+            if ((try self.findSliceParamForLen(params, param.name)) == null) continue;
+
+            var first: ?reg.Command.Param = null;
+            for (params) |p| {
+                if ((try self.classifyParam(params, p)) != .slice) continue;
+                if (!mem.eql(u8, p.param_type.pointer.size.other_field, param.name)) continue;
+                // Can't access .len directly on ?[]const T
+                if (p.param_type.pointer.is_optional and try self.isPlainSlice(params, p)) continue;
+
+                if (first) |f| {
+                    try self.writer.writeAll("std.debug.assert(");
+                    try self.renderParamName(f.name);
+                    try self.writer.writeAll(".len == ");
+                    try self.renderParamName(p.name);
+                    try self.writer.writeAll(".len);\n");
+                } else {
+                    first = p;
+                }
+            }
         }
     }
 };

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1949,7 +1949,7 @@ const Renderer = struct {
 
         if (returns.len == 1 and returns[0].origin == .inner_return_value) {
             try self.writer.writeAll("{\n");
-            try self.renderSliceLenAsserts(command.params);
+            try self.renderSliceLenAsserts(name, command.params);
 
             if (returns_vk_result) {
                 try self.writer.writeAll("const result = ");
@@ -1974,7 +1974,7 @@ const Renderer = struct {
             "return_values";
 
         try self.writer.writeAll("{\n");
-        try self.renderSliceLenAsserts(command.params);
+        try self.renderSliceLenAsserts(name, command.params);
 
         if (returns.len == 1) {
             try self.writer.writeAll("var ");
@@ -2090,7 +2090,7 @@ const Renderer = struct {
         try self.renderAllocWrapperPrototype(name, params, returns_vk_result, data_type, "", .wrapper);
 
         try self.writer.writeAll("{\n");
-        try self.renderSliceLenAsserts(params);
+        try self.renderSliceLenAsserts(wrapped_name, params);
         try self.writer.writeAll("    var count: ");
         try self.renderTypeInfo(count_type);
         try self.writer.writeAll(" = undefined;\n");
@@ -2270,34 +2270,68 @@ const Renderer = struct {
         return true;
     }
 
-    fn renderSliceLenAsserts(self: *Self, params: []const reg.Command.Param) !void {
+    // NOTE: if multiple buffer args are linked to a single count parameter and they are all optional (this never happens in the vulkan spec yet)
+    // the generated assertions will not be exhaustive
+    fn renderSliceLenAsserts(self: *Self, function_name: []const u8, params: []const reg.Command.Param) !void {
         for (params) |len_param| {
             if ((try self.classifyParam(params, len_param)) != .buffer_len) continue;
-            const ref = (try self.findRefSliceParam(params, len_param.name)) orelse continue;
 
-            for (params, 0..) |other, i| {
-                if (i == ref.idx) continue;
-                if ((try self.classifyParam(params, other)) != .slice) continue;
-                if (!mem.eql(u8, other.param_type.pointer.size.other_field, len_param.name)) continue;
+            const ref_result = (try self.findRefSliceParam(params, len_param.name)) orelse continue;
+            const ref_slice = ref_result.param;
+            const ref_slice_opt = ref_slice.param_type.pointer.is_optional;
+            const len_param_kept = !try self.shouldSkipLen(function_name, params, len_param);
 
-                const ref_opt = ref.param.param_type.pointer.is_optional;
-                const other_opt = other.param_type.pointer.is_optional;
+            const ref_param, const ref_is_slice, const ref_is_opt = switch (ref_slice_opt) {
+                false => .{ ref_slice, true, false },
+                true => switch (len_param_kept) {
+                    true => .{ len_param, false, false },
+                    false => .{ ref_slice, true, true },
+                },
+            };
+
+            for (params) |other| {
+                const other_class = try self.classifyParam(params, other);
+                switch (other_class) {
+                    .slice => {
+                        if (!mem.eql(u8, other.param_type.pointer.size.other_field, len_param.name)) continue;
+                        if (ref_is_slice and mem.eql(u8, other.name, ref_param.name)) continue;
+                    },
+                    .buffer_len => {
+                        if (!mem.eql(u8, other.name, len_param.name)) continue;
+                        if (!ref_is_slice) continue;
+                        if (try self.shouldSkipLen(function_name, params, other)) continue;
+                    },
+                    else => continue,
+                }
+
+                const other_is_slice = other_class == .slice;
+                const other_opt = if (other_is_slice) other.param_type.pointer.is_optional else false;
 
                 try self.writer.writeAll("std.debug.assert(");
-                if (ref_opt) {
-                    try self.renderParamName(ref.param.name);
+                if (ref_is_opt) {
+                    try self.renderParamName(ref_param.name);
                     try self.writer.writeAll(" == null or ");
                 }
                 if (other_opt) {
                     try self.renderParamName(other.name);
                     try self.writer.writeAll(" == null or ");
                 }
-                try self.renderParamName(ref.param.name);
-                if (ref_opt) try self.writer.writeAll(".?");
-                try self.writer.writeAll(".len == ");
+
+                try self.renderParamName(ref_param.name);
+                if (ref_is_slice) {
+                    if (ref_is_opt) try self.writer.writeAll(".?");
+                    try self.writer.writeAll(".len");
+                }
+
+                try self.writer.writeAll(" == ");
+
                 try self.renderParamName(other.name);
-                if (other_opt) try self.writer.writeAll(".?");
-                try self.writer.writeAll(".len);\n");
+                if (other_is_slice) {
+                    if (other_opt) try self.writer.writeAll(".?");
+                    try self.writer.writeAll(".len");
+                }
+
+                try self.writer.writeAll(");\n");
             }
         }
     }

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -96,6 +96,43 @@ const preamble =
     \\    name: [:0]const u8 = "custom",
     \\    version: Version = makeApiVersion(0, 0, 0, 0),
     \\};
+    \\pub fn Slice(comptime Ptr: type, comptime LenT: type) type {
+    \\    const info = @typeInfo(Ptr);
+    \\    const ptr_info = switch (info) {
+    \\        .pointer => info.pointer,
+    \\        .optional => @typeInfo(info.optional.child).pointer,
+    \\        else => @compileError("expected pointer or optional pointer"),
+    \\    };
+    \\    const is_opt = switch (info) {
+    \\        .optional => true,
+    \\        else => false,
+    \\    };
+    \\    const NonOptSlice = if (ptr_info.is_const) []const ptr_info.child else []ptr_info.child;
+    \\    return struct {
+    \\        ptr: Ptr,
+    \\        len: LenT,
+    \\
+    \\        pub const SliceT = if (is_opt) ?NonOptSlice else NonOptSlice;
+    \\
+    \\        pub fn fromSlice(slice: SliceT) @This() {
+    \\            if (is_opt) {
+    \\                if (slice) |s| {
+    \\                    return .{ .ptr = s.ptr, .len = @intCast(s.len) };
+    \\                }
+    \\                return .{ .ptr = null, .len = 0 };
+    \\            }
+    \\            return .{ .ptr = slice.ptr, .len = @intCast(slice.len) };
+    \\        }
+    \\
+    \\        pub fn toSlice(self: @This()) SliceT {
+    \\            if (is_opt) {
+    \\                const p = self.ptr orelse return null;
+    \\                return p[0..@intCast(self.len)];
+    \\            }
+    \\            return self.ptr[0..@intCast(self.len)];
+    \\        }
+    \\    };
+    \\}
 ;
 
 // Keep in sync with above definition of FlagsMixin
@@ -362,6 +399,7 @@ const Renderer = struct {
         mut_buffer_len,
         buffer_len,
         dispatch_handle,
+        slice,
         other,
     };
 
@@ -563,7 +601,7 @@ const Renderer = struct {
         return false;
     }
 
-    fn classifyParam(self: Self, param: reg.Command.Param) !ParamType {
+    fn classifyParam(self: Self, params: []const reg.Command.Param, param: reg.Command.Param) !ParamType {
         switch (param.param_type) {
             .pointer => |ptr| {
                 if (param.is_buffer_len) {
@@ -581,6 +619,17 @@ const Renderer = struct {
                     } else if (builtin_types.get(child_name) == null and trimVkNamespace(child_name).ptr == child_name.ptr) {
                         return .other; // External type
                     }
+                }
+
+                if (ptr.size == .other_field) {
+                    for (params) |p| {
+                        if (mem.eql(u8, p.name, ptr.size.other_field)) {
+                            // If the length param is a pointer (mut_buffer_len), not a slice
+                            if (p.param_type == .pointer) return .other;
+                            return .slice;
+                        }
+                    }
+                    return .other;
                 }
 
                 if (ptr.size == .one and !ptr.is_optional) {
@@ -1643,8 +1692,14 @@ const Renderer = struct {
         try self.writer.writeByte('(');
 
         for (command.params) |param| {
-            switch (try self.classifyParam(param)) {
+            switch (try self.classifyParam(command.params, param)) {
                 .out_pointer => continue,
+                .buffer_len => {
+                    if ((try self.findSliceParamForLen(command.params, param.name)) != null) {
+                        continue;
+                    }
+                    try self.renderParamName(param.name);
+                },
                 .dispatch_handle => {
                     if (mem.eql(u8, param.param_type.name, dispatch_handle)) {
                         try self.writer.writeAll("self.handle");
@@ -1700,8 +1755,14 @@ const Renderer = struct {
         try self.writer.writeByte('(');
 
         for (params) |param| {
-            switch (try self.classifyParam(param)) {
+            switch (try self.classifyParam(params, param)) {
                 .out_pointer => return error.InvalidRegistry,
+                .buffer_len => {
+                    if ((try self.findSliceParamForLen(params, param.name)) != null) {
+                        continue;
+                    }
+                    try self.renderParamName(param.name);
+                },
                 .dispatch_handle => {
                     if (mem.eql(u8, param.param_type.name, dispatch_handle)) {
                         try self.writer.writeAll("self.handle");
@@ -1776,18 +1837,23 @@ const Renderer = struct {
         try self.writer.writeAll("(self: Self, ");
 
         for (command.params) |param| {
-            const class = try self.classifyParam(param);
+            const class = try self.classifyParam(command.params, param);
             // Skip the dispatch type for proxying wrappers
             if (kind == .proxy and class == .dispatch_handle and mem.eql(u8, param.param_type.name, dispatch_handle)) {
                 continue;
             }
-
             // This parameter is returned instead.
             if (class == .out_pointer) {
                 continue;
             }
-
-            try self.renderWrapperParam(param);
+            if (try self.shouldSkipLen(command.params, param)) {
+                continue;
+            }
+            if (class == .slice) {
+                try self.renderSliceParam(command.params, param);
+            } else {
+                try self.renderWrapperParam(param);
+            }
         }
 
         try self.writer.writeAll(") ");
@@ -1819,7 +1885,7 @@ const Renderer = struct {
         try self.writer.writeAll(".?(");
 
         for (command.params) |param| {
-            switch (try self.classifyParam(param)) {
+            switch (try self.classifyParam(command.params, param)) {
                 .out_pointer => {
                     try self.writer.writeByte('&');
                     try self.writeIdentifierWithCase(.snake, return_var_name.?);
@@ -1828,7 +1894,19 @@ const Renderer = struct {
                         try self.renderParamName(derefName(param.name));
                     }
                 },
-                else => try self.renderParamName(param.name),
+                .buffer_len => {
+                    if (try self.findSliceParamForLen(command.params, param.name)) |slice_param| {
+                        try self.renderSliceLenCallArg(command.params, slice_param);
+                    } else {
+                        try self.renderParamName(param.name);
+                    }
+                },
+                .slice => {
+                    try self.renderSlicePtrCallArg(command.params, param);
+                },
+                else => {
+                    try self.renderParamName(param.name);
+                },
             }
 
             try self.writer.writeAll(", ");
@@ -1866,7 +1944,7 @@ const Renderer = struct {
         }
 
         for (command.params) |param| {
-            if ((try self.classifyParam(param)) == .out_pointer) {
+            if ((try self.classifyParam(command.params, param)) == .out_pointer) {
                 try returns.append(allocator, .{
                     .name = derefName(param.name),
                     .return_value_type = param.param_type.pointer.child.*,
@@ -1997,12 +2075,18 @@ const Renderer = struct {
         try self.renderWrapperName(name, "", .wrapper);
         try self.writer.writeAll("(self: Self, ");
         for (params) |param| {
-            const class = try self.classifyParam(param);
-            // Skip the dispatch type for proxying wrappers
+            const class = try self.classifyParam(params, param);
             if (kind == .proxy and class == .dispatch_handle and mem.eql(u8, param.param_type.name, dispatch_handle)) {
                 continue;
             }
-            try self.renderWrapperParam(param);
+            if (try self.shouldSkipLen(params, param)) {
+                continue;
+            }
+            if (class == .slice) {
+                try self.renderSliceParam(params, param);
+            } else {
+                try self.renderWrapperParam(param);
+            }
         }
         try self.writer.writeAll("allocator: Allocator,) ");
 
@@ -2070,13 +2154,7 @@ const Renderer = struct {
             );
         }
 
-        try self.writer.writeAll(" self.");
-        try self.renderWrapperName(wrapped_name, "", .wrapper);
-        try self.writer.writeAll("(\n");
-        for (params) |param| {
-            try self.renderParamName(param.name);
-            try self.writer.writeAll(", ");
-        }
+        try self.renderAllocCallParams(wrapped_name, params);
         try self.writer.writeAll("&count, null);\n");
 
         if (returns_vk_result) {
@@ -2093,13 +2171,7 @@ const Renderer = struct {
             );
         }
 
-        try self.writer.writeAll(" self.");
-        try self.renderWrapperName(wrapped_name, "", .wrapper);
-        try self.writer.writeAll("(\n");
-        for (params) |param| {
-            try self.renderParamName(param.name);
-            try self.writer.writeAll(", ");
-        }
+        try self.renderAllocCallParams(wrapped_name, params);
         try self.writer.writeAll("&count, data.ptr);\n");
 
         if (returns_vk_result) {
@@ -2110,6 +2182,30 @@ const Renderer = struct {
             \\    return if (count == data.len) data else allocator.realloc(data, count);
             \\}
         );
+    }
+
+    fn renderAllocCallParams(self: *Self, wrapped_name: []const u8, params: []const reg.Command.Param) !void {
+        try self.writer.writeAll(" self.");
+        try self.renderWrapperName(wrapped_name, "", .wrapper);
+        try self.writer.writeAll("(\n");
+        for (params) |param| {
+            switch (try self.classifyParam(params, param)) {
+                .buffer_len => {
+                    if (try self.findSliceParamForLen(params, param.name)) |slice_param| {
+                        try self.renderSliceLenCallArg(params, slice_param);
+                    } else {
+                        try self.renderParamName(param.name);
+                    }
+                },
+                .slice => {
+                    try self.renderSlicePtrCallArg(params, param);
+                },
+                else => {
+                    try self.renderParamName(param.name);
+                },
+            }
+            try self.writer.writeAll(", ");
+        }
     }
 
     fn renderErrorSwitch(self: *Self, result_var: []const u8, command: reg.Command) !void {
@@ -2154,6 +2250,75 @@ const Renderer = struct {
             // Apparently some commands (VkAcquireProfilingLockInfoKHR) return
             // success codes as error...
             try self.writeIdentifierWithCase(.title, trimVkNamespace(name));
+        }
+    }
+
+    fn findSliceParamForLen(self: Self, params: []const reg.Command.Param, len_name: []const u8) !?reg.Command.Param {
+        for (params) |param| {
+            if ((try self.classifyParam(params, param)) == .slice) {
+                if (mem.eql(u8, param.param_type.pointer.size.other_field, len_name)) {
+                    return param;
+                }
+            }
+        }
+        return null;
+    }
+
+    fn shouldSkipLen(self: Self, params: []const reg.Command.Param, param: reg.Command.Param) !bool {
+        if ((try self.classifyParam(params, param)) != .buffer_len) return false;
+        return (try self.findSliceParamForLen(params, param.name)) != null;
+    }
+
+    fn isPlainSlice(self: Self, params: []const reg.Command.Param, param: reg.Command.Param) !bool {
+        if ((try self.classifyParam(params, param)) != .slice) return false;
+        const len_param = for (params) |p| {
+            if (mem.eql(u8, p.name, param.param_type.pointer.size.other_field)) break p;
+        } else return false;
+        if (len_param.param_type != .name) return false;
+        const zig_name = builtin_types.get(len_param.param_type.name) orelse return false;
+        return mem.eql(u8, zig_name, @typeName(usize));
+    }
+
+    fn renderSliceParam(self: *Self, params: []const reg.Command.Param, param: reg.Command.Param) !void {
+        const ptr = param.param_type.pointer;
+        const len_param = for (params) |p| {
+            if (mem.eql(u8, p.name, ptr.size.other_field)) break p;
+        } else return error.InvalidRegistry;
+
+        try self.renderParamName(param.name);
+        try self.writer.writeAll(": Slice(");
+        if (ptr.is_optional) {
+            try self.writer.writeByte('?');
+        }
+        try self.writer.writeAll("[*]");
+        if (ptr.is_const) {
+            try self.writer.writeAll("const ");
+        }
+        try self.renderTypeInfo(ptr.child.*);
+        try self.writer.writeAll(", ");
+        try self.renderTypeInfo(len_param.param_type);
+        try self.writer.writeAll("), ");
+    }
+
+    fn renderSlicePtrCallArg(self: *Self, params: []const reg.Command.Param, param: reg.Command.Param) !void {
+        if (param.param_type.pointer.is_optional and try self.isPlainSlice(params, param)) {
+            try self.writer.writeAll("if (");
+            try self.renderParamName(param.name);
+            try self.writer.writeAll(") |s| s.ptr else null");
+        } else {
+            try self.renderParamName(param.name);
+            try self.writer.writeAll(".ptr");
+        }
+    }
+
+    fn renderSliceLenCallArg(self: *Self, params: []const reg.Command.Param, slice_param: reg.Command.Param) !void {
+        if (slice_param.param_type.pointer.is_optional and try self.isPlainSlice(params, slice_param)) {
+            try self.writer.writeAll("if (");
+            try self.renderParamName(slice_param.name);
+            try self.writer.writeAll(") |s| s.len else 0");
+        } else {
+            try self.renderParamName(slice_param.name);
+            try self.writer.writeAll(".len");
         }
     }
 };


### PR DESCRIPTION
At first I thought this was a bad idea but I've actually came around to thinking this is better than status quo, thoughts?
In my mind the tradeoff is:

positives:
 - remove the footgun of giving the wrong length value (I have been bit by this)
 - more ergonomic in most cases

 negatives:
 - departure from the original api
 - less clear that you are effectively casting the lenght integer
 - a bit more complexity

before:
```zig
pub fn cmdBindVertexBuffers(
    self: Self,
    command_buffer: CommandBuffer,
    first_binding: u32,
    binding_count: u32,
    p_buffers: [*]const Buffer,
    p_offsets: [*]const DeviceSize,
) void {
    self.dispatch.vkCmdBindVertexBuffers.?(
        command_buffer,
        first_binding,
        binding_count,
        p_buffers,
        p_offsets,
    );
}
```

after:
```zig
pub fn cmdBindVertexBuffers(
    self: Self,
    command_buffer: CommandBuffer,
    first_binding: u32,
    p_buffers: []const Buffer,
    p_offsets: []const DeviceSize,
) void {
    std.debug.assert(p_buffers.len == p_offsets.len);
    self.dispatch.vkCmdBindVertexBuffers.?(
        command_buffer,
        first_binding,
        @intCast(p_buffers.len),
        p_buffers.ptr,
        p_offsets.ptr,
    );
}
```

user code:
```zig
// before:
gc.dev.cmdBindVertexBuffers(cmdbuf, 0, 1, @ptrCast(&buffer), &offset);
// after:
gc.dev.cmdBindVertexBuffers(cmdbuf, 0, &.{buffer}, &offset);
```