### PR TITLE
Add build.zig.zon to paths for correct hash

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,6 +4,7 @@
     .version = "0.0.0",
     .minimum_zig_version = "0.16.0-dev.1859+212968c57",
     .paths = .{
+        "build.zig.zon",
         "build.zig",
         "LICENSE",
         "README.md",


### PR DESCRIPTION
Fixes error observed when vulkan-zig is used as a dependency of a dependency:
```
hash mismatch: manifest declares 'vulkan-0.0.0-r7Ytx2pIAwBu_hx9thyACY0w0OKvjrCWrLZeBBAiMTiq' but the fetched package has 'N-V-__8AAGpIAwBu_hx9thyACY0w0OKvjrCWrLZeBBAiMTiq'
```
