### PR TITLE
bugfix: fix issue with inferred backing integer for zig 0.16

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1286,9 +1286,9 @@ const Renderer = struct {
             try self.writer.writeAll("pub const ");
             try self.renderName(name);
             try self.writer.print(
-                \\ = packed struct {{
+                \\ = packed struct({s}) {{
                 \\_reserved_bits: {s} = 0,
-            , .{flags_type});
+            , .{ flags_type, flags_type });
             try self.renderFlagFunctions(name, "FlagsMixin", flag_functions, null);
             try self.writer.writeAll("};\n");
         }


### PR DESCRIPTION
```
.zig-cache/o/7e24f806e59fc3b69eb7b29c4827f556/vk.zig:1011:12: note: inferred backing integer of packed struct has unspecified signedness
.zig-cache/o/7e24f806e59fc3b69eb7b29c4827f556/vk.zig:273:38: note: struct declared here
pub const DeviceCreateFlags = packed struct {
                              ~~~~~~~^~~~~~
referenced by:
    init: src/device.zig:226:9
    app_init: examples/01Shader.zig:222:37
    8 reference(s) hidden; use '-freference-trace=10' to see all references
.zig-cache/o/7e24f806e59fc3b69eb7b29c4827f556/vk.zig:3785:12: error: extern structs cannot contain fields of type 'vk.DebugUtilsMessengerCallbackDataFlagsEXT'
    flags: DebugUtilsMessengerCallbackDataFlagsEXT = .{},
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.zig-cache/o/7e24f806e59fc3b69eb7b29c4827f556/vk.zig:3785:12: note: inferred backing integer of packed struct has unspecified signedness
.zig-cache/o/7e24f806e59fc3b69eb7b29c4827f556/vk.zig:658:60: note: struct declared here
pub const DebugUtilsMessengerCallbackDataFlagsEXT = packed struct {
                                                    ~~~~~~~^~~~~~
```