### PR TITLE
Allow pointers in function pointers to be nullable

### DIFF
--- a/src/vulkan/parse.zig
+++ b/src/vulkan/parse.zig
@@ -291,7 +291,7 @@ fn parseFuncPointer(allocator: Allocator, ty: *xml.Element, api: registry.Api) !
     // The layout of this field changed somewhere around version 339. Just try to parse it as the new
     // version first and fall back to the old version of that fails...
 
-    const decl = parseCommand(allocator, ty, api) catch {
+    const decl = parseCommand(allocator, ty, api, true) catch {
         // Old definitions were a typedef like this
         //
         // <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
@@ -550,7 +550,7 @@ fn parseCommands(
         if (!requiredByApi(elem, api))
             continue;
 
-        try decls.append(allocator, try parseCommand(allocator, elem, api));
+        try decls.append(allocator, try parseCommand(allocator, elem, api, false));
     }
 }
 
@@ -569,7 +569,7 @@ fn splitCommaAlloc(allocator: Allocator, text: []const u8) ![][]const u8 {
     return codes;
 }
 
-fn parseCommand(allocator: Allocator, elem: *xml.Element, api: registry.Api) !registry.Declaration {
+fn parseCommand(allocator: Allocator, elem: *xml.Element, api: registry.Api, ptrs_optional: bool) !registry.Declaration {
     if (elem.getAttribute("alias")) |alias| {
         const name = elem.getAttribute("name") orelse return error.InvalidRegistry;
         return registry.Declaration{
@@ -582,7 +582,7 @@ fn parseCommand(allocator: Allocator, elem: *xml.Element, api: registry.Api) !re
 
     const proto = elem.findChildByTag("proto") orelse return error.InvalidRegistry;
     var proto_xctok = cparse.XmlCTokenizer.init(proto);
-    const command_decl = try cparse.parseParamOrProto(allocator, &proto_xctok, false);
+    const command_decl = try cparse.parseParamOrProto(allocator, &proto_xctok, ptrs_optional);
 
     var params = try allocator.alloc(registry.Command.Param, elem.children.len);
 
@@ -593,7 +593,7 @@ fn parseCommand(allocator: Allocator, elem: *xml.Element, api: registry.Api) !re
             continue;
 
         var xctok = cparse.XmlCTokenizer.init(param);
-        const decl = try cparse.parseParamOrProto(allocator, &xctok, false);
+        const decl = try cparse.parseParamOrProto(allocator, &xctok, ptrs_optional);
         params[i] = .{
             .name = decl.name,
             .param_type = decl.decl_type.typedef,


### PR DESCRIPTION
Currently, it's impossible to implement a custom allocator for Vulkan due to the fact that all pointers are treated as not-nullable.

This was supposedly fixed for https://github.com/Snektron/vulkan-zig/issues/32, but I'm guessing it regressed with Vulkan version 339.

Most function pointers receive `pUserData`, which is also nullable, so to keep things simple, all parameters are also set as optionals.

Will need cherry-picks for the compat branches (I was actually using the 0.15 branch, not master).