### PR TITLE
Update example: zig-shader location

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .vulkan,
     .fingerprint = 0xbe155a03c72db6af,
     .version = "0.0.0",
-    .minimum_zig_version = "0.16.0-dev.3142+5ccfeb926",
+    .minimum_zig_version = "0.16.0-dev.3153+d6f43caad",
     .paths = .{
         "build.zig.zon",
         "build.zig",

--- a/examples/shaders/fragment.zig
+++ b/examples/shaders/fragment.zig
@@ -1,12 +1,15 @@
 const std = @import("std");
 const gpu = std.gpu;
 
-extern const v_color: @Vector(3, f32) addrspace(.input);
-extern var f_color: @Vector(4, f32) addrspace(.output);
+const v_color = @extern(*addrspace(.input) @Vector(3, f32), .{
+    .name = "v_color",
+    .decoration = .{ .location = 0 },
+});
+const f_color = @extern(*addrspace(.output) @Vector(4, f32), .{
+    .name = "f_color",
+    .decoration = .{ .location = 0 },
+});
 
 export fn main() callconv(.spirv_fragment) void {
-    gpu.location(&v_color, 0);
-    gpu.location(&f_color, 0);
-
-    f_color = .{ v_color[0], v_color[1], v_color[2], 1.0 };
+    f_color.* = .{ v_color.*[0], v_color.*[1], v_color.*[2], 1.0 };
 }

--- a/examples/shaders/vertex.zig
+++ b/examples/shaders/vertex.zig
@@ -1,16 +1,20 @@
 const std = @import("std");
 const gpu = std.gpu;
 
-extern const a_pos: @Vector(2, f32) addrspace(.input);
-extern const a_color: @Vector(3, f32) addrspace(.input);
-
-extern var v_color: @Vector(3, f32) addrspace(.output);
+const a_pos = @extern(*addrspace(.input) @Vector(2, f32), .{
+    .name = "a_pos",
+    .decoration = .{ .location = 0 },
+});
+const a_color = @extern(*addrspace(.input) @Vector(3, f32), .{
+    .name = "a_color",
+    .decoration = .{ .location = 1 },
+});
+const v_color = @extern(*addrspace(.output) @Vector(3, f32), .{
+    .name = "v_color",
+    .decoration = .{ .location = 0 },
+});
 
 export fn main() callconv(.spirv_vertex) void {
-    gpu.location(&a_pos, 0);
-    gpu.location(&a_color, 1);
-    gpu.location(&v_color, 0);
-
-    gpu.position_out.* = .{ a_pos[0], a_pos[1], 0.0, 1.0 };
-    v_color = a_color;
+    gpu.position_out.* = .{ a_pos.*[0], a_pos.*[1], 0.0, 1.0 };
+    v_color.* = a_color.*;
 }


### PR DESCRIPTION
This pr updates the example. It updates the shader location according to zig 0.16.0 changes on master branch. The change happened in this commit: `0ea79c85b2b22266a0b25edf04c392add8387d5b`.