### PR TITLE
Change Bool32 to exhaustive enum

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -906,10 +906,9 @@ const Renderer = struct {
         if (std.mem.eql(u8, basename, "VkBool32")) {
             try self.renderAssign(name);
             try self.writer.writeAll(
-                \\enum(i32) {
+                \\enum(u32) {
                 \\    false,
                 \\    true,
-                \\    _,
                 \\};
                 \\
             );


### PR DESCRIPTION
There's no reason for Bool32 to be non-exhaustive. From the spec:

> VkBool32 represents boolean True and False values, since C does not have a sufficiently portable built-in boolean type:
>
> ```c
> // Provided by VK_VERSION_1_0
> typedef uint32_t VkBool32;
> ```
>
> VK_TRUE represents a boolean True (unsigned integer 1) value, and VK_FALSE a boolean False (unsigned integer 0) value.
>
> All values returned from a Vulkan implementation in a VkBool32 will be either VK_TRUE or VK_FALSE.
>
> Applications must not pass any other values than VK_TRUE or VK_FALSE into a Vulkan implementation where a VkBool32 is expected.

It's normative that neither the user nor the implementation is allowed to set an instance of this type to anything other than 0 or 1. It's also technically unsigned.