### PR TITLE
Replaces inline for loops with proper runtime loops.

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1479,7 +1479,7 @@ const Renderer = struct {
 
     fn renderDispatchTable(self: *Self, dispatch_type: CommandDispatchType) !void {
         try self.writer.print(
-            "pub const {s}Dispatch = struct {{\n",
+            "pub const {s}Dispatch = extern struct {{\n",
             .{dispatch_type.name()},
         );
 
@@ -1505,20 +1505,9 @@ const Renderer = struct {
 
     fn renderWrappers(self: *Self) !void {
         try self.writer.writeAll(command_flags_mixin);
-        try self.renderWrappersCommon();
         try self.renderWrappersOfDispatchType(.base);
         try self.renderWrappersOfDispatchType(.instance);
         try self.renderWrappersOfDispatchType(.device);
-    }
-
-    fn renderWrappersCommon(self: *Self) !void {
-        try self.writer.print(
-            \\fn loadCommonImpl(loader: *const fn(usize, [*:0]const u8) PfnVoidFunction, handle: usize, names: []const [*:0]const u8, ptrs: [*]PfnVoidFunction) void {{
-            \\    for (ptrs[0..names.len], names) |*ptr, name| {{
-            \\        ptr.* = loader(handle, name);
-            \\    }}
-            \\}}
-        , .{});
     }
 
     fn renderWrappersOfDispatchType(self: *Self, dispatch_type: CommandDispatchType) !void {
@@ -1527,7 +1516,7 @@ const Renderer = struct {
         try self.writer.print(
             \\pub const {0s}Wrapper = {0s}WrapperWithCustomDispatch({0s}Dispatch);
             \\pub fn {0s}WrapperWithCustomDispatch(DispatchType: type) type {{
-            \\    return struct {{
+            \\    return extern struct {{
             \\        const Self = @This();
             \\        pub const Dispatch = DispatchType;
             \\
@@ -1564,9 +1553,9 @@ const Renderer = struct {
 
     fn renderWrapperLoader(self: *Self, dispatch_type: CommandDispatchType) !void {
         const params = switch (dispatch_type) {
-            .base => "loader: *const fn(Instance, [*:0]const u8) PfnVoidFunction",
-            .instance => "instance: Instance, loader: *const fn(Instance, [*:0]const u8) PfnVoidFunction",
-            .device => "device: Device, loader: *const fn(Device, [*:0]const u8) PfnVoidFunction",
+            .base => "loader: anytype",
+            .instance => "instance: Instance, loader: anytype",
+            .device => "device: Device, loader: anytype",
         };
 
         const loader_first_arg = switch (dispatch_type) {
@@ -1586,7 +1575,10 @@ const Renderer = struct {
             \\        for (&names, fields) |*d, f| d.* = f.name.ptr;
             \\        break :blk names;
             \\    }};
-            \\    loadCommonImpl(@ptrCast(loader), @intFromEnum({[first_arg]s}), &names, @ptrCast(&self.dispatch));
+            \\    const self_as_ptr: [*]?*const anyopaque = @ptrCast(&self.dispatch);
+            \\    for (self_as_ptr[0..names.len], names) |*ptr, name| {{
+            \\        ptr.* = loader({[first_arg]s}, name);
+            \\    }}            
             \\    return self;
             \\}}
         , .{ .params = params, .first_arg = loader_first_arg });

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1505,9 +1505,20 @@ const Renderer = struct {
 
     fn renderWrappers(self: *Self) !void {
         try self.writer.writeAll(command_flags_mixin);
+        try self.renderWrappersCommon();
         try self.renderWrappersOfDispatchType(.base);
         try self.renderWrappersOfDispatchType(.instance);
         try self.renderWrappersOfDispatchType(.device);
+    }
+
+    fn renderWrappersCommon(self: *Self) !void {
+        try self.writer.print(
+            \\fn loadCommonImpl(loader: *const fn(usize, [*:0]const u8) PfnVoidFunction, handle: usize, names: []const [*:0]const u8, ptrs: [*]PfnVoidFunction) void {{
+            \\    for (ptrs[0..names.len], names) |*ptr, name| {{
+            \\        ptr.* = loader(handle, name);
+            \\    }}
+            \\}}
+        , .{});
     }
 
     fn renderWrappersOfDispatchType(self: *Self, dispatch_type: CommandDispatchType) !void {
@@ -1553,9 +1564,9 @@ const Renderer = struct {
 
     fn renderWrapperLoader(self: *Self, dispatch_type: CommandDispatchType) !void {
         const params = switch (dispatch_type) {
-            .base => "loader: anytype",
-            .instance => "instance: Instance, loader: anytype",
-            .device => "device: Device, loader: anytype",
+            .base => "loader: *const fn(Instance, [*:0]const u8) PfnVoidFunction",
+            .instance => "instance: Instance, loader: *const fn(Instance, [*:0]const u8) PfnVoidFunction",
+            .device => "device: Device, loader: *const fn(Device, [*:0]const u8) PfnVoidFunction",
         };
 
         const loader_first_arg = switch (dispatch_type) {
@@ -1569,11 +1580,13 @@ const Renderer = struct {
         try self.writer.print(
             \\pub fn load({[params]s}) Self {{
             \\    var self: Self = .{{ .dispatch = .{{}} }};
-            \\    inline for (std.meta.fields(Dispatch)) |field| {{
-            \\        if (loader({[first_arg]s}, field.name.ptr)) |cmd_ptr| {{
-            \\            @field(self.dispatch, field.name) = @ptrCast(cmd_ptr);
-            \\        }}
-            \\    }}
+            \\    const names = comptime blk:{{ 
+            \\        const fields = @typeInfo(Dispatch).@"struct".fields;
+            \\        var names: [fields.len][*:0]const u8 = undefined;
+            \\        for (&names, fields) |*d, f| d.* = f.name.ptr;
+            \\        break :blk names;
+            \\    }};
+            \\    loadCommonImpl(@ptrCast(loader), @intFromEnum({[first_arg]s}), &names, @ptrCast(&self.dispatch));
             \\    return self;
             \\}}
         , .{ .params = params, .first_arg = loader_first_arg });


### PR DESCRIPTION
Current `load` functions make use of inline loops:

```zig
pub fn BaseWrapperWithCustomDispatch(DispatchType: type) type {
    return struct {
        const Self = @This();
        pub const Dispatch = DispatchType;

        dispatch: Dispatch,
        pub fn load(loader: anytype) Self {
            var self: Self = .{ .dispatch = .{} };
            inline for (std.meta.fields(Dispatch)) |field| {
                if (loader(Instance.null_handle, field.name.ptr)) |cmd_ptr| {
                    @field(self.dispatch, field.name) = @ptrCast(cmd_ptr);
                }
            }
            return self;
         }
```

This generates a lot of bloat. Here's a small program for code analysis:

```zig
const vk = @import("vk");

fn loadStuff(a: vk.Device, b: [*:0]const u8) vk.PfnVoidFunction {
    return asm volatile (""
        : [ret] "={rax}" (-> vk.PfnVoidFunction),
        : [a] "r" (a),
          [b] "r" (b),
    );
}

pub fn main() void {
    const w: vk.DeviceWrapper = .load(@enumFromInt(1), loadStuff);
    _ = w;
}
```

Here's the generated assembly:
```asm
push rbp
mov rbp, rsp
lea rax, [0x00007FF60FEA3000]
mov ecx, 0x01
lea rax, [0x00007FF60FEA3010]
lea rax, [0x00007FF60FEA3021]
lea rax, [0x00007FF60FEA302F]
lea rax, [0x00007FF60FEA303F]
lea rax, [0x00007FF60FEA3050]
lea rax, [0x00007FF60FEA3061]
...
```

I truncated it. It just goes on forever.

We can make this better by noticing that `Dispatch` is supposed to be just an array of pointers. Since fields of same size follow source code order, we can cast the dispatch to a slice, and replace the loop with a proper runtime loop. Also, all handles lower to just a `usize`.
Here's the generated `load` function with this patch:

```zig
fn loadCommonImpl(loader: *const fn (usize, [*:0]const u8) PfnVoidFunction, handle: usize, names: []const [*:0]const u8, ptrs: [*]PfnVoidFunction) void {
    for (ptrs[0..names.len], names) |*ptr, name| {
        ptr.* = loader(handle, name);
    }
}
pub const BaseWrapper = BaseWrapperWithCustomDispatch(BaseDispatch);
pub fn BaseWrapperWithCustomDispatch(DispatchType: type) type {
    return struct {
        const Self = @This();
        pub const Dispatch = DispatchType;

        dispatch: Dispatch,
        pub fn load(loader: *const fn (Instance, [*:0]const u8) PfnVoidFunction) Self {
            var self: Self = .{ .dispatch = .{} };
            const names = comptime blk: {
                const fields = @typeInfo(Dispatch).@"struct".fields;
                var names: [fields.len][*:0]const u8 = undefined;
                for (&names, fields) |*d, f| d.* = f.name.ptr;
                break :blk names;
            };
            loadCommonImpl(@ptrCast(loader), @intFromEnum(Instance.null_handle), &names, @ptrCast(&self.dispatch));
            return self;
        }
```

And here's the generated assembly from that sample program:

```asm
push rbp
mov rbp, rsp
xor ecx, ecx
lea rdx, [0x00007FF796052000]
mov r8d, 0x01
nop [rax+rax*1], ax
mov rax, [rcx+rdx*1]
add rcx, 0x08
cmp rcx, 0x1668
jnz 0x00007FF796051040 (main)
pop rbp
ret
```

That's the entire thing.
