### PR TITLE
Split `extensions` namespace

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 
 const required_layer_names = [_][*:0]const u8{"VK_LAYER_KHRONOS_validation"};
 
-const required_device_extensions = [_][*:0]const u8{vk.extensions.khr_swapchain.name};
+const required_device_extensions = [_][*:0]const u8{vk.device_extensions.khr_swapchain.name};
 
 /// There are 3 levels of bindings in vulkan-zig:
 /// - The Dispatch types (vk.BaseDispatch, vk.InstanceDispatch, vk.DeviceDispatch)
@@ -65,11 +65,11 @@ pub const GraphicsContext = struct {
 
         var extension_names: std.ArrayList([*:0]const u8) = .empty;
         defer extension_names.deinit(allocator);
-        try extension_names.append(allocator, vk.extensions.ext_debug_utils.name);
+        try extension_names.append(allocator, vk.instance_extensions.ext_debug_utils.name);
         // the following extensions are to support vulkan in mac os
         // see https://github.com/glfw/glfw/issues/2335
-        try extension_names.append(allocator, vk.extensions.khr_portability_enumeration.name);
-        try extension_names.append(allocator, vk.extensions.khr_get_physical_device_properties_2.name);
+        try extension_names.append(allocator, vk.instance_extensions.khr_portability_enumeration.name);
+        try extension_names.append(allocator, vk.instance_extensions.khr_get_physical_device_properties_2.name);
 
         var glfw_exts_count: u32 = 0;
         const glfw_exts = c.glfwGetRequiredInstanceExtensions(&glfw_exts_count);

--- a/src/vulkan/generator.zig
+++ b/src/vulkan/generator.zig
@@ -100,8 +100,10 @@ const EnumFieldMerger = struct {
             try self.addRequires(feature.requires);
         }
 
-        for (self.registry.extensions) |ext| {
-            try self.addRequires(ext.requires);
+        for ([_][]const reg.Extension{ self.registry.instance_extensions, self.registry.device_extensions, self.registry.video_extensions }) |extensions| {
+            for (extensions) |ext| {
+                try self.addRequires(ext.requires);
+            }
         }
 
         // Merge all the enum fields.

--- a/src/vulkan/parse.zig
+++ b/src/vulkan/parse.zig
@@ -32,20 +32,22 @@ pub fn parseXml(
     var api_constants: std.ArrayList(registry.ApiConstant) = .empty;
     var tags: std.ArrayList(registry.Tag) = .empty;
     var features: std.ArrayList(registry.Feature) = .empty;
-    var extensions: std.ArrayList(registry.Extension) = .empty;
+    var instance_extensions: std.ArrayList(registry.Extension) = .empty;
+    var device_extensions: std.ArrayList(registry.Extension) = .empty;
+    var video_extensions: std.ArrayList(registry.Extension) = .empty;
 
     try parseDeclarations(allocator, root, api, &decls);
     try parseApiConstants(allocator, root, api, &api_constants);
     try parseTags(allocator, root, &tags);
     try parseFeatures(allocator, root, api, &features);
-    try parseExtensions(allocator, root, api, &extensions);
+    try parseExtensions(allocator, root, api, &instance_extensions, &device_extensions, &video_extensions);
 
     if (maybe_video_root) |video_root| {
         try parseDeclarations(allocator, video_root, api, &decls);
         try parseApiConstants(allocator, video_root, api, &api_constants);
         try parseTags(allocator, video_root, &tags);
         try parseFeatures(allocator, video_root, api, &features);
-        try parseExtensions(allocator, video_root, api, &extensions);
+        try parseExtensions(allocator, video_root, api, &instance_extensions, &device_extensions, &video_extensions);
     }
 
     const reg = registry.Registry{
@@ -53,7 +55,9 @@ pub fn parseXml(
         .api_constants = api_constants.items,
         .tags = tags.items,
         .features = features.items,
-        .extensions = extensions.items,
+        .instance_extensions = instance_extensions.items,
+        .device_extensions = device_extensions.items,
+        .video_extensions = video_extensions.items,
     };
 
     return ParseResult{
@@ -936,10 +940,11 @@ fn parseExtensions(
     allocator: Allocator,
     root: *xml.Element,
     api: registry.Api,
-    extensions: *std.ArrayList(registry.Extension),
+    instance_extensions: *std.ArrayList(registry.Extension),
+    device_extensions: *std.ArrayList(registry.Extension),
+    video_extensions: *std.ArrayList(registry.Extension),
 ) !void {
     const extensions_elem = root.findChildByTag("extensions") orelse return error.InvalidRegistry;
-    try extensions.ensureUnusedCapacity(allocator, extensions_elem.children.len);
 
     var it = extensions_elem.findChildrenByTag("extension");
     while (it.next()) |extension| {
@@ -952,7 +957,7 @@ fn parseExtensions(
             }
         }
 
-        extensions.appendAssumeCapacity(try parseExtension(allocator, extension, api));
+        try parseExtension(allocator, extension, api, instance_extensions, device_extensions, video_extensions);
     }
 }
 
@@ -975,7 +980,14 @@ fn findExtVersion(extension: *xml.Element) !registry.Extension.Version {
     return .unknown;
 }
 
-fn parseExtension(allocator: Allocator, extension: *xml.Element, api: registry.Api) !registry.Extension {
+fn parseExtension(
+    allocator: Allocator,
+    extension: *xml.Element,
+    api: registry.Api,
+    instance_extensions: *std.ArrayList(registry.Extension),
+    device_extensions: *std.ArrayList(registry.Extension),
+    video_extensions: *std.ArrayList(registry.Extension),
+) !void {
     const name = extension.getAttribute("name") orelse return error.InvalidRegistry;
     const platform = extension.getAttribute("platform");
 
@@ -1002,19 +1014,17 @@ fn parseExtension(allocator: Allocator, extension: *xml.Element, api: registry.A
     };
 
     const number = blk: {
-        // Vulkan Video extensions do not have numbers.
-        if (is_video) break :blk 0;
         const number_str = extension.getAttribute("number") orelse return error.InvalidRegistry;
         break :blk try std.fmt.parseInt(u31, number_str, 10);
     };
 
-    const ext_type: ?registry.Extension.ExtensionType = blk: {
-        if (is_video) break :blk .video;
-        const ext_type_str = extension.getAttribute("type") orelse break :blk null;
+    const array_list = blk: {
+        if (is_video) break :blk video_extensions;
+        const ext_type_str = extension.getAttribute("type") orelse return error.InvalidRegistry;
         if (mem.eql(u8, ext_type_str, "instance")) {
-            break :blk .instance;
+            break :blk instance_extensions;
         } else if (mem.eql(u8, ext_type_str, "device")) {
-            break :blk .device;
+            break :blk device_extensions;
         } else {
             return error.InvalidRegistry;
         }
@@ -1035,17 +1045,16 @@ fn parseExtension(allocator: Allocator, extension: *xml.Element, api: registry.A
         i += 1;
     }
 
-    return registry.Extension{
+    try array_list.append(allocator, registry.Extension{
         .name = name,
         .number = number,
         .version = version,
-        .extension_type = ext_type,
         .depends = depends,
         .promoted_to = promoted_to,
         .platform = platform,
         .required_feature_level = requires_core,
         .requires = requires[0..i],
-    };
+    });
 }
 
 fn splitFeatureLevel(ver: []const u8, split: []const u8) !registry.FeatureLevel {

--- a/src/vulkan/registry.zig
+++ b/src/vulkan/registry.zig
@@ -8,7 +8,9 @@ pub const Registry = struct {
     api_constants: []ApiConstant,
     tags: []Tag,
     features: []Feature,
-    extensions: []Extension,
+    instance_extensions: []Extension,
+    device_extensions: []Extension,
+    video_extensions: []Extension,
 };
 
 pub const Declaration = struct {
@@ -181,12 +183,6 @@ pub const Feature = struct {
 };
 
 pub const Extension = struct {
-    pub const ExtensionType = enum {
-        instance,
-        device,
-        video,
-    };
-
     pub const Promotion = union(enum) {
         none,
         feature: FeatureLevel,
@@ -202,7 +198,6 @@ pub const Extension = struct {
     name: []const u8,
     number: u31,
     version: Version,
-    extension_type: ?ExtensionType,
     depends: []const []const u8, // Other extensions
     promoted_to: Promotion,
     platform: ?[]const u8,

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1443,14 +1443,10 @@ const Renderer = struct {
         try self.writer.writeAll("};\n");
     }
 
-    fn renderExtensionInfo(self: *Self) !void {
-        try self.writer.writeAll(
-            \\pub const extensions = struct {
-            \\
-        );
-        for (self.registry.extensions) |ext| {
+    fn renderExtensionInfoImpl(self: *Self, extensions: []const reg.Extension, comptime is_video: bool) !void {
+        for (extensions) |ext| {
             try self.writer.writeAll("pub const ");
-            if (ext.extension_type == .video) {
+            if (comptime is_video) {
                 // These are already in the right form, and the auto-casing style transformer
                 // is prone to messing up these names.
                 try self.writeIdentifier(trimVkNamespace(ext.name));
@@ -1469,6 +1465,24 @@ const Renderer = struct {
             try self.writer.writeAll(",};\n");
         }
         try self.writer.writeAll("};\n");
+    }
+
+    fn renderExtensionInfo(self: *Self) !void {
+        try self.writer.writeAll(
+            \\pub const instance_extensions = struct {
+            \\
+        );
+        try self.renderExtensionInfoImpl(self.registry.instance_extensions, false);
+        try self.writer.writeAll(
+            \\pub const device_extensions = struct {
+            \\
+        );
+        try self.renderExtensionInfoImpl(self.registry.device_extensions, false);
+        try self.writer.writeAll(
+            \\pub const video_extensions = struct {
+            \\
+        );
+        try self.renderExtensionInfoImpl(self.registry.video_extensions, true);
     }
 
     fn renderDispatchTables(self: *Self) !void {


### PR DESCRIPTION
I can never remember which extensions are instance or device extensions.
This PR splits the `extensions` namespace into `instance_extensions`, `device_extensions` and `video_extensions`.