### PR TITLE
Fix underlying type of C enums

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1217,7 +1217,7 @@ const Renderer = struct {
 
         try self.writer.writeAll("pub const ");
         try self.renderName(name);
-        try self.writer.writeAll(" = enum(i32) {");
+        try self.writer.writeAll(" = enum(c_int) {");
 
         for (enumeration.fields) |field| {
             if (field.value == .alias)


### PR DESCRIPTION
C enums should have type `c_int`, as they are not guaranteed to be 32 bit wide. The C standard only requires they be signed types with bitwidth >= 16.

Example of generated code:
```
// before
pub const AttachmentLoadOp = enum(i32) {

// after
pub const AttachmentLoadOp = enum(c_int) {
```