### PR TITLE
removed usage of the `**` repeat operator

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1273,10 +1273,10 @@ const Renderer = struct {
         if (bits.fields.len == 0) {
             try self.writer.print("_reserved_bits: {s} = 0,", .{flags_type});
         } else {
-            var flags_by_bitpos = [_]?struct {
+            var flags_by_bitpos: [64]?struct {
                 name: []const u8,
                 comment: ?[]const u8,
-            }{null} ** 64;
+            } = @splat(null);
             for (bits.fields) |field| {
                 if (field.value == .bitpos) {
                     flags_by_bitpos[field.value.bitpos] = .{


### PR DESCRIPTION
Updated vulkan/render.zig to initialise `flags_by_bitops` with the builtin `@splat` instead of the removed `**` repeat operator.

The repeat operator has been removed from zig in master.

https://github.com/ziglang/zig/issues/24738