### PR TITLE
std.meta.Tuple is deprecated

### DIFF
--- a/src/vulkan/parse.zig
+++ b/src/vulkan/parse.zig
@@ -341,7 +341,7 @@ const Fields = union(enum) {
 };
 
 // returns .{ size, nullable }
-fn lenToPointer(fields: Fields, len: []const u8) struct {registry.Pointer.PointerSize, bool} {
+fn lenToPointer(fields: Fields, len: []const u8) struct { registry.Pointer.PointerSize, bool } {
     switch (fields) {
         .command => |params| {
             for (params) |*param| {

--- a/src/vulkan/parse.zig
+++ b/src/vulkan/parse.zig
@@ -341,7 +341,7 @@ const Fields = union(enum) {
 };
 
 // returns .{ size, nullable }
-fn lenToPointer(fields: Fields, len: []const u8) std.meta.Tuple(&.{ registry.Pointer.PointerSize, bool }) {
+fn lenToPointer(fields: Fields, len: []const u8) struct {registry.Pointer.PointerSize, bool} {
     switch (fields) {
         .command => |params| {
             for (params) |*param| {


### PR DESCRIPTION
Currently in the master branch of zig std.meta.Tuple is deprecated and caused compile errors when trying to build vulkan-zig. This issue was fixed by changing the return type of the lenToPointer function to return an anonymous struct with the same types used to define the original tuple. 