### PR TITLE
update to zig 0.17 836

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .vulkan,
     .fingerprint = 0xbe155a03c72db6af,
     .version = "0.0.0",
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.836+e357134f0",
     .paths = .{
         "build.zig.zon",
         "build.zig",

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1569,9 +1569,9 @@ const Renderer = struct {
         try self.writer.print(
             \\pub fn load({[params]s}) Self {{
             \\    var self: Self = .{{ .dispatch = .{{}} }};
-            \\    inline for (std.meta.fields(Dispatch)) |field| {{
-            \\        if (loader({[first_arg]s}, field.name.ptr)) |cmd_ptr| {{
-            \\            @field(self.dispatch, field.name) = @ptrCast(cmd_ptr);
+            \\    inline for (@typeInfo(Dispatch).@"struct".field_names) |field| {{
+            \\        if (loader({[first_arg]s}, field.ptr)) |cmd_ptr| {{
+            \\            @field(self.dispatch, field) = @ptrCast(cmd_ptr);
             \\        }}
             \\    }}
             \\    return self;

--- a/test/ref_all_decls.zig
+++ b/test/ref_all_decls.zig
@@ -99,10 +99,10 @@ comptime {
 
 fn reallyRefAllDecls(comptime T: type) void {
     switch (@typeInfo(T)) {
-        .@"struct", .@"union" => {
+        inline .@"struct", .@"union" => |info| {
             reallyRefAllContainerDecls(T);
-            inline for (std.meta.fields(T)) |field| {
-                reallyRefAllDecls(field.type);
+            inline for (info.field_types) |field_ty| {
+                reallyRefAllDecls(field_ty);
             }
         },
         .@"enum", .@"opaque" => {
@@ -114,8 +114,8 @@ fn reallyRefAllDecls(comptime T: type) void {
 
 fn reallyRefAllContainerDecls(comptime T: type) void {
     inline for (comptime std.meta.declarations(T)) |decl| {
-        if (@TypeOf(@field(T, decl.name)) == type) {
-            reallyRefAllDecls(@field(T, decl.name));
+        if (@TypeOf(@field(T, decl)) == type) {
+            reallyRefAllDecls(@field(T, decl));
         }
     }
 }


### PR DESCRIPTION
Changes in the zig standard library caused the library to no longer compile. This should fix it.

Closes #252
Supersedes #251