### PR TITLE
better identifier name casing conversion

### DIFF
--- a/src/id_render.zig
+++ b/src/id_render.zig
@@ -82,12 +82,19 @@ pub const SegmentIterator = struct {
                 return i;
             }
 
-            const prev_lower = std.ascii.isLower(self.text[i - 1]);
-            const next_lower = std.ascii.isLower(self.text[i]);
+            const prev_char = self.text[i - 1];
+            const next_char = self.text[i];
+            const prev_upper = std.ascii.isUpper(prev_char);
+            const prev_lower = std.ascii.isLower(prev_char);
+            const next_lower = std.ascii.isLower(next_char);
 
             if (prev_lower and !next_lower) {
-                return i;
-            } else if (i != self.offset + 1 and !prev_lower and next_lower) {
+                // keep a lowercase separator when in between digits (eg `4x4`).
+                const in_between_digits =
+                    std.ascii.isDigit(next_char) and
+                    i >= 2 and std.ascii.isDigit(self.text[i - 2]);
+                if (!in_between_digits) return i;
+            } else if (i != self.offset + 1 and prev_upper and next_lower) {
                 return i - 1;
             }
 


### PR DESCRIPTION
a few example of what this changes:

integer_dot_product_4x_8_bit_packed_signed_accelerated => integer_dot_product_4x8_bit_packed_signed_accelerated
use_6_4bit_texturing => use_64bit_texturing
format_rgba_1_0x_6_without_y_cb_cr_sampler => format_rgba_10x6_without_y_cb_cr_sampler
astc_4x_4_unorm_block => astc_4x4_unorm_block

