### PR TITLE
render VK_ERROR_VALIDATION_FAILED as a panic instead of an error

### DIFF
--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -2204,8 +2204,15 @@ const Renderer = struct {
         for (command.error_codes) |err| {
             try self.writer.writeAll("Result.");
             try self.renderEnumFieldName("VkResult", err);
-            try self.writer.writeAll(" => return error.");
-            try self.renderResultAsErrorName(err);
+            try self.writer.writeAll(" => ");
+            if (std.mem.eql(u8, err, "VK_ERROR_VALIDATION_FAILED_EXT") or
+                std.mem.eql(u8, err, "VK_ERROR_VALIDATION_FAILED"))
+            {
+                try self.writer.writeAll("std.debug.panic(\"VK_ERROR_VALIDATION_FAILED: invalid API usage\", .{})");
+            } else {
+                try self.writer.writeAll("return error.");
+                try self.renderResultAsErrorName(err);
+            }
             try self.writer.writeAll(", ");
         }
 
@@ -2215,7 +2222,10 @@ const Renderer = struct {
     fn renderErrorSet(self: *Self, errors: []const []const u8) !void {
         try self.writer.writeAll("error{");
         for (errors) |name| {
-            if (std.mem.eql(u8, name, "VK_ERROR_UNKNOWN")) {
+            if (std.mem.eql(u8, name, "VK_ERROR_UNKNOWN") or
+                std.mem.eql(u8, name, "VK_ERROR_VALIDATION_FAILED_EXT") or
+                std.mem.eql(u8, name, "VK_ERROR_VALIDATION_FAILED"))
+            {
                 continue;
             }
             try self.renderResultAsErrorName(name);


### PR DESCRIPTION
closes #254

And option to log and ignore it instead of panic can be added later if needed.