### PR TITLE
remove _bit suffix from bitflag field names

### DIFF
--- a/examples/graphics_context.zig
+++ b/examples/graphics_context.zig
@@ -87,9 +87,9 @@ pub const GraphicsContext = struct {
             .pp_enabled_layer_names = @ptrCast(&required_layer_names),
             .enabled_extension_count = @intCast(extension_names.items.len),
             .pp_enabled_extension_names = extension_names.items.ptr,
-            // enumerate_portability_bit_khr to support vulkan in mac os
+            // enumerate_portability_khr to support vulkan in mac os
             // see https://github.com/glfw/glfw/issues/2335
-            .flags = .{ .enumerate_portability_bit_khr = true },
+            .flags = .{ .enumerate_portability_khr = true },
         }, null);
 
         const vki = try allocator.create(InstanceWrapper);
@@ -100,15 +100,15 @@ pub const GraphicsContext = struct {
 
         self.debug_messenger = try self.instance.createDebugUtilsMessengerEXT(&.{
             .message_severity = .{
-                //.verbose_bit_ext = true,
-                //.info_bit_ext = true,
-                .warning_bit_ext = true,
-                .error_bit_ext = true,
+                //.verbose_ext = true,
+                //.info_ext = true,
+                .warning_ext = true,
+                .error_ext = true,
             },
             .message_type = .{
-                .general_bit_ext = true,
-                .validation_bit_ext = true,
-                .performance_bit_ext = true,
+                .general_ext = true,
+                .validation_ext = true,
+                .performance_ext = true,
             },
             .pfn_user_callback = &debugUtilsMessengerCallback,
             .p_user_data = null,
@@ -152,9 +152,9 @@ pub const GraphicsContext = struct {
         return std.mem.sliceTo(&self.props.device_name, 0);
     }
 
-    pub fn findMemoryTypeIndex(self: GraphicsContext, memory_type_bits: u32, flags: vk.MemoryPropertyFlags) !u32 {
+    pub fn findMemoryTypeIndex(self: GraphicsContext, memory_types: u32, flags: vk.MemoryPropertyFlags) !u32 {
         for (self.mem_props.memory_types[0..self.mem_props.memory_type_count], 0..) |mem_type, i| {
-            if (memory_type_bits & (@as(u32, 1) << @truncate(i)) != 0 and mem_type.property_flags.contains(flags)) {
+            if (memory_types & (@as(u32, 1) << @truncate(i)) != 0 and mem_type.property_flags.contains(flags)) {
                 return @truncate(i);
             }
         }
@@ -254,9 +254,9 @@ const QueueAllocation = struct {
 };
 
 fn debugUtilsMessengerCallback(severity: vk.DebugUtilsMessageSeverityFlagsEXT, msg_type: vk.DebugUtilsMessageTypeFlagsEXT, callback_data: ?*const vk.DebugUtilsMessengerCallbackDataEXT, _: ?*anyopaque) callconv(.c) vk.Bool32 {
-    const severity_str = if (severity.verbose_bit_ext) "verbose" else if (severity.info_bit_ext) "info" else if (severity.warning_bit_ext) "warning" else if (severity.error_bit_ext) "error" else "unknown";
+    const severity_str = if (severity.verbose_ext) "verbose" else if (severity.info_ext) "info" else if (severity.warning_ext) "warning" else if (severity.error_ext) "error" else "unknown";
 
-    const type_str = if (msg_type.general_bit_ext) "general" else if (msg_type.validation_bit_ext) "validation" else if (msg_type.performance_bit_ext) "performance" else if (msg_type.device_address_binding_bit_ext) "device addr" else "unknown";
+    const type_str = if (msg_type.general_ext) "general" else if (msg_type.validation_ext) "validation" else if (msg_type.performance_ext) "performance" else if (msg_type.device_address_binding_ext) "device addr" else "unknown";
 
     const message: [*c]const u8 = if (callback_data) |cb_data| cb_data.p_message else "NO MESSAGE!";
     std.debug.print("[{s}][{s}]. Message:\n  {s}\n", .{ severity_str, type_str, message });
@@ -317,7 +317,7 @@ fn allocateQueues(instance: Instance, pdev: vk.PhysicalDevice, allocator: Alloca
     for (families, 0..) |properties, i| {
         const family: u32 = @intCast(i);
 
-        if (graphics_family == null and properties.queue_flags.graphics_bit) {
+        if (graphics_family == null and properties.queue_flags.graphics) {
             graphics_family = family;
         }
 

--- a/examples/swapchain.zig
+++ b/examples/swapchain.zig
@@ -53,12 +53,12 @@ pub const Swapchain = struct {
             .image_color_space = surface_format.color_space,
             .image_extent = actual_extent,
             .image_array_layers = 1,
-            .image_usage = .{ .color_attachment_bit = true, .transfer_dst_bit = true },
+            .image_usage = .{ .color_attachment = true, .transfer_dst = true },
             .image_sharing_mode = sharing_mode,
             .queue_family_index_count = qfi.len,
             .p_queue_family_indices = &qfi,
             .pre_transform = caps.current_transform,
-            .composite_alpha = .{ .opaque_bit_khr = true },
+            .composite_alpha = .{ .opaque_khr = true },
             .present_mode = present_mode,
             .clipped = .true,
             .old_swapchain = old_handle,
@@ -178,7 +178,7 @@ pub const Swapchain = struct {
         try self.gc.dev.resetFences(&.{current.frame_fence});
 
         // Step 2: Submit the command buffer
-        const wait_stage = [_]vk.PipelineStageFlags{.{ .top_of_pipe_bit = true }};
+        const wait_stage = [_]vk.PipelineStageFlags{.{ .top_of_pipe = true }};
         try self.gc.dev.queueSubmit(self.gc.graphics_queue.handle, &.{.{
             .wait_semaphore_count = 1,
             .p_wait_semaphores = @ptrCast(&current.image_acquired),
@@ -231,7 +231,7 @@ const SwapImage = struct {
             .format = format,
             .components = .{ .r = .identity, .g = .identity, .b = .identity, .a = .identity },
             .subresource_range = .{
-                .aspect_mask = .{ .color_bit = true },
+                .aspect_mask = .{ .color = true },
                 .base_mip_level = 0,
                 .level_count = 1,
                 .base_array_layer = 0,
@@ -246,7 +246,7 @@ const SwapImage = struct {
         const render_finished = try gc.dev.createSemaphore(&.{}, null);
         errdefer gc.dev.destroySemaphore(render_finished, null);
 
-        const frame_fence = try gc.dev.createFence(&.{ .flags = .{ .signaled_bit = true } }, null);
+        const frame_fence = try gc.dev.createFence(&.{ .flags = .{ .signaled = true } }, null);
         errdefer gc.dev.destroyFence(frame_fence, null);
 
         return SwapImage{

--- a/examples/triangle.zig
+++ b/examples/triangle.zig
@@ -117,12 +117,12 @@ pub fn main() !void {
 
     const buffer = try gc.dev.createBuffer(&.{
         .size = @sizeOf(@TypeOf(vertices)),
-        .usage = .{ .transfer_dst_bit = true, .vertex_buffer_bit = true },
+        .usage = .{ .transfer_dst = true, .vertex_buffer = true },
         .sharing_mode = .exclusive,
     }, null);
     defer gc.dev.destroyBuffer(buffer, null);
     const mem_reqs = gc.dev.getBufferMemoryRequirements(buffer);
-    const memory = try gc.allocate(mem_reqs, .{ .device_local_bit = true });
+    const memory = try gc.allocate(mem_reqs, .{ .device_local = true });
     defer gc.dev.freeMemory(memory, null);
     try gc.dev.bindBufferMemory(buffer, memory, 0);
 
@@ -190,12 +190,12 @@ pub fn main() !void {
 fn uploadVertices(gc: *const GraphicsContext, pool: vk.CommandPool, buffer: vk.Buffer) !void {
     const staging_buffer = try gc.dev.createBuffer(&.{
         .size = @sizeOf(@TypeOf(vertices)),
-        .usage = .{ .transfer_src_bit = true },
+        .usage = .{ .transfer_src = true },
         .sharing_mode = .exclusive,
     }, null);
     defer gc.dev.destroyBuffer(staging_buffer, null);
     const mem_reqs = gc.dev.getBufferMemoryRequirements(staging_buffer);
-    const staging_memory = try gc.allocate(mem_reqs, .{ .host_visible_bit = true, .host_coherent_bit = true });
+    const staging_memory = try gc.allocate(mem_reqs, .{ .host_visible = true, .host_coherent = true });
     defer gc.dev.freeMemory(staging_memory, null);
     try gc.dev.bindBufferMemory(staging_buffer, staging_memory, 0);
 
@@ -222,7 +222,7 @@ fn copyBuffer(gc: *const GraphicsContext, pool: vk.CommandPool, dst: vk.Buffer, 
     const cmdbuf = GraphicsContext.CommandBuffer.init(cmdbuf_handle, gc.dev.wrapper);
 
     try cmdbuf.beginCommandBuffer(&.{
-        .flags = .{ .one_time_submit_bit = true },
+        .flags = .{ .one_time_submit = true },
     });
 
     const region = vk.BufferCopy{
@@ -347,7 +347,7 @@ fn destroyFramebuffers(gc: *const GraphicsContext, allocator: Allocator, framebu
 fn createRenderPass(gc: *const GraphicsContext, swapchain: Swapchain) !vk.RenderPass {
     const color_attachment = vk.AttachmentDescription{
         .format = swapchain.surface_format.format,
-        .samples = .{ .@"1_bit" = true },
+        .samples = .{ .@"1" = true },
         .load_op = .clear,
         .store_op = .store,
         .stencil_load_op = .dont_care,
@@ -394,12 +394,12 @@ fn createPipeline(
 
     const pssci = [_]vk.PipelineShaderStageCreateInfo{
         .{
-            .stage = .{ .vertex_bit = true },
+            .stage = .{ .vertex = true },
             .module = vert,
             .p_name = "main",
         },
         .{
-            .stage = .{ .fragment_bit = true },
+            .stage = .{ .fragment = true },
             .module = frag,
             .p_name = "main",
         },
@@ -428,7 +428,7 @@ fn createPipeline(
         .depth_clamp_enable = .false,
         .rasterizer_discard_enable = .false,
         .polygon_mode = .fill,
-        .cull_mode = .{ .back_bit = true },
+        .cull_mode = .{ .back = true },
         .front_face = .clockwise,
         .depth_bias_enable = .false,
         .depth_bias_constant_factor = 0,
@@ -438,7 +438,7 @@ fn createPipeline(
     };
 
     const pmsci = vk.PipelineMultisampleStateCreateInfo{
-        .rasterization_samples = .{ .@"1_bit" = true },
+        .rasterization_samples = .{ .@"1" = true },
         .sample_shading_enable = .false,
         .min_sample_shading = 1,
         .alpha_to_coverage_enable = .false,
@@ -453,7 +453,7 @@ fn createPipeline(
         .src_alpha_blend_factor = .one,
         .dst_alpha_blend_factor = .zero,
         .alpha_blend_op = .add,
-        .color_write_mask = .{ .r_bit = true, .g_bit = true, .b_bit = true, .a_bit = true },
+        .color_write_mask = .{ .r = true, .g = true, .b = true, .a = true },
     };
 
     const pcbsci = vk.PipelineColorBlendStateCreateInfo{

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -1286,13 +1286,25 @@ const Renderer = struct {
                 }
             }
 
+            var arena: std.heap.ArenaAllocator = .init(self.allocator);
+            defer arena.deinit();
+
             for (flags_by_bitpos[0..bits.bitwidth], 0..) |maybe_flag, bitpos| {
+                defer _ = arena.reset(.retain_capacity);
                 if (maybe_flag) |flag| {
                     if (flag.comment) |comment| {
                         try self.renderDocComment(comment);
                     }
                     const field_name = try extractBitflagFieldName(bitflag_name, flag.name);
-                    try self.writeIdentifierWithCase(.snake, field_name);
+                    const name_without_bit = blk: {
+                        const bit_prefix = "_BIT";
+                        const index = std.mem.lastIndexOf(u8, field_name, bit_prefix) orelse break :blk field_name;
+                        break :blk try std.mem.concat(arena.allocator(), u8, &.{
+                            field_name[0..index],
+                            field_name[index + bit_prefix.len ..],
+                        });
+                    };
+                    try self.writeIdentifierWithCase(.snake, name_without_bit);
                 } else {
                     try self.writer.print("_reserved_bit_{}", .{bitpos});
                 }


### PR DESCRIPTION
The `_bit` suffix doesnt make sense like it does in C, every field is already a `bool`. Other bindings do this too like Rust's ash.

before:
```zig
.{ .color_attachment_bit = true, .transfer_dst_bit = true }
```

after:
```zig
.{ .color_attachment = true, .transfer_dst = true }
```