### PR TITLE
Update std.zig.Ast.parse to be compatible with master

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -152,7 +152,7 @@ pub fn main(init: std.process.Init) !void {
 
     const buffered = aw.writer.buffered();
     const src = buffered[0 .. buffered.len - 1 :0];
-    const tree = std.zig.Ast.parse(allocator, src, .zig) catch |err| switch (err) {
+    const tree = std.zig.Ast.parse(allocator, src, .{ .mode = .zig }) catch |err| switch (err) {
         error.OutOfMemory => oomPanic(),
     };
 


### PR DESCRIPTION
The std.zig.Ast.parse function seems to have been changed. This pr simply updates the code to work with the zig master.