### PR TITLE
add fromBool function to Bool32

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const vkgen = @import("vulkan_zig");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/src/vulkan/render.zig
+++ b/src/vulkan/render.zig
@@ -909,6 +909,9 @@ const Renderer = struct {
                 \\enum(u32) {
                 \\    false,
                 \\    true,
+                \\    pub fn fromBool(b: bool) Bool32 {
+                \\        return if (b) .true else .false;
+                \\    }
                 \\};
                 \\
             );


### PR DESCRIPTION
Doesn't add `toBool` because `foo == .true` is almost as simple as `foo.toBool()`. That reflects zig having `@intFromBool` but not `@boolFromInt`.

Also removes an unused import in examples/build.zig